### PR TITLE
Add dev container to the project

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"name": "nvmefs",
+	"image": "ghcr.io/xnvme/xnvme-deps-alpine-latest:next",
+	"postCreateCommand": "bash -i .devcontainer/install-dependencies.sh"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,16 @@
 {
 	"name": "nvmefs",
 	"image": "ghcr.io/xnvme/xnvme-deps-alpine-latest:next",
-	"postCreateCommand": "bash -i .devcontainer/install-dependencies.sh"
+	"postCreateCommand": "bash -i .devcontainer/install-dependencies.sh",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"VisualStudioExptTeam.vscodeintellicode",
+				"VisualStudioExptTeam.intellicode-api-usage-examples",
+				"ms-vscode.cpptools",
+				"ms-vscode.cpptools-extension-pack",
+				"ms-vscode.cmake-tools"
+			]
+		}
+	}
 }

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Install xnvme libraries 
+bash -i ./scripts/xnvme/install.sh
+
+# Install dev dependencies
+apk --no-cache add cmake ccache

--- a/scripts/xnvme/install.sh
+++ b/scripts/xnvme/install.sh
@@ -15,8 +15,7 @@
 #   available and fetched. If not, search for how 
 #   to fetch a git submodules files.
 
-# OLD_PWD="${PWD}"
-# XNVME_DEV_ROOT="./third-party/xnvme"
+XNVME_DEV_ROOT="./third-party/xnvme"
 
 # Change working directory
 cd $XNVME_DEV_ROOT

--- a/scripts/xnvme/install.sh
+++ b/scripts/xnvme/install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+############################################
+######## Install xNVMe Dependencies ########
+############################################
+# Description:
+#   This script is responsible for building and installing
+#   xNVMe libraries to your machine, using the files from
+#   the attached git submodule 'third-party/xnvme'.
+#
+# Assumptions:
+#   It is assumed that this script is being executed from
+#   the root of the nvmefs project directory. 
+#   Additionally, the files in the submodule has to be
+#   available and fetched. If not, search for how 
+#   to fetch a git submodules files.
+
+# OLD_PWD="${PWD}"
+# XNVME_DEV_ROOT="./third-party/xnvme"
+
+# Change working directory
+cd $XNVME_DEV_ROOT
+
+# configure xNVMe and build meson subprojects(SPDK)
+meson setup builddir
+
+# build xNVMe
+meson compile -C builddir
+
+# install xNVMe
+meson install -C builddir


### PR DESCRIPTION
# What does this PR include?

This PR adds the possibility to run the development environment in a linux based operating system. This allows for users that do not use Linux as their primary OS to develop for features that is only available in Linux. 

This is a requirement since using IO Passthru features can be done using Liburing which leverages `io_uring_cmd`(again only available in Linux OS).

> [!IMPORTANT]
> If you have already started developing in this repo and that you have compiles the application and extension using `make` or `GEN=ninja make`,  _**you have to clean all build files**_. You can do this in the devcontainer by running the command `make clean` and then again run `make` or `GEN=ninja make`. 