### PR TITLE
Change default temporary_directory when using NvmeFs

### DIFF
--- a/src/nvmefs_extension.cpp
+++ b/src/nvmefs_extension.cpp
@@ -159,6 +159,7 @@ namespace duckdb
 	static void AddConfig(DatabaseInstance &instance)
 	{
 		DBConfig &config = DBConfig::GetConfig(instance);
+		config.options.temporary_directory = "nvme:///tmp";
 
 		auto &fs = instance.GetFileSystem();
 		KeyValueSecretReader secret_reader(instance, "nvmefs", "nvmefs://");

--- a/src/nvmefs_extension.cpp
+++ b/src/nvmefs_extension.cpp
@@ -137,6 +137,11 @@ namespace duckdb
 			chunk_count++;
 		}
 
+		// Output the temporary directory
+		output.SetValue(0, chunk_count, Value("temporary_directory"));
+		output.SetValue(1, chunk_count, Value(context.db->config.options.temporary_directory));
+		chunk_count++;
+
 		output.SetCardinality(chunk_count);
 
 		data.finished = true;
@@ -160,6 +165,8 @@ namespace duckdb
 	{
 		DBConfig &config = DBConfig::GetConfig(instance);
 		config.options.temporary_directory = "nvme:///tmp";
+
+		std::cout << config.options.temporary_directory << std::endl;
 
 		auto &fs = instance.GetFileSystem();
 		KeyValueSecretReader secret_reader(instance, "nvmefs", "nvmefs://");

--- a/src/nvmefs_extension.cpp
+++ b/src/nvmefs_extension.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/extension_util.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/main/settings.hpp"
 #include "nvmefs_proxy.hpp"
 #include "nvmefs_secret.hpp"
 
@@ -56,8 +57,13 @@ static unique_ptr<FunctionData> ConfigPrintBind(ClientContext &ctx, TableFunctio
 }
 
 static void AddConfig(DatabaseInstance &instance) {
+
 	DBConfig &config = DBConfig::GetConfig(instance);
 
+	// Change global settings
+	TempDirectorySetting::SetGlobal(&instance, config, Value("nvmefs:///tmp"));
+
+	// Add extension options
 	auto &fs = instance.GetFileSystem();
 	KeyValueSecretReader secret_reader(instance, "nvmefs", "nvmefs://");
 

--- a/src/nvmefs_extension.cpp
+++ b/src/nvmefs_extension.cpp
@@ -166,8 +166,6 @@ namespace duckdb
 		DBConfig &config = DBConfig::GetConfig(instance);
 		config.options.temporary_directory = "nvme:///tmp";
 
-		std::cout << config.options.temporary_directory << std::endl;
-
 		auto &fs = instance.GetFileSystem();
 		KeyValueSecretReader secret_reader(instance, "nvmefs", "nvmefs://");
 


### PR DESCRIPTION

# What has been changed?

Since we need the `nvme://` prefix to determine if our file system is to be used, the config had to be changed.
That is what this PR is about. When the extension is loaded then the default config will be changed to use the
new path of the temporary directory.

### Changes

- **Change the temporary directory path**
- **Add temporary directory to print_config() function**
