### PR TITLE
Fix start location for each category of data when using read and write without location as a parameter

### DIFF
--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -56,14 +56,13 @@ protected:
 class NvmeFileSystemProxy;
 class NvmeFileSystem : public FileSystem {
 	friend class NvmeFileSystemProxy;
+
 public:
 	NvmeFileSystem(NvmeFileSystemProxy &proxy_ref);
 	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
 	                                optional_ptr<FileOpener> opener = nullptr) override;
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
-	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
-	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 	bool CanHandleFile(const string &fpath) override;
 
 	string GetName() const {

--- a/src/include/nvmefs_proxy.hpp
+++ b/src/include/nvmefs_proxy.hpp
@@ -54,13 +54,13 @@ public:
 		return "NvmeFileSystemProxy";
 	}
 
-
 private:
 	unique_ptr<GlobalMetadata> LoadMetadata(optional_ptr<FileOpener> opener);
 	unique_ptr<GlobalMetadata> InitializeMetadata(optional_ptr<FileOpener> opener);
 	void WriteMetadata(uint64_t location, uint64_t nr_lbas, MetadataType type);
 	MetadataType GetMetadataType(string path);
 	uint64_t GetLBA(MetadataType type, string filename, idx_t location);
+	uint64_t GetStartLBA(MetadataType type, string filename);
 
 private:
 	Allocator &allocator;

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -206,16 +206,6 @@ uint64_t NvmeFileSystem::WriteInternal(FileHandle &handle, void *buffer, int64_t
 	return nvme_ctx->number_of_lbas;
 }
 
-int64_t NvmeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
-	Read(handle, buffer, nr_bytes, 0);
-	return nr_bytes;
-}
-
-int64_t NvmeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
-	Write(handle, buffer, nr_bytes, 0);
-	return nr_bytes;
-}
-
 bool NvmeFileSystem::CanHandleFile(const string &path) {
 	return StringUtil::StartsWith(path, NVMEFS_PATH_PREFIX);
 }

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -141,7 +141,7 @@ unique_ptr<FileHandle> NvmeFileSystem::OpenFile(const string &path, FileOpenFlag
 	secret_reader.TryGetSecretKeyOrSetting("fdp_plhdls", "fdp_plhdls", plid_count);
 
 	unique_ptr<NvmeFileHandle> file_handler =
-	    make_uniq<NvmeFileHandle>(proxy_filesystem, path, placement_identifier_index, device, plid_count);
+	    make_uniq<NvmeFileHandle>(proxy_filesystem, path, placement_identifier_index, device, plid_count, flags);
 
 	return std::move(file_handler);
 }

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -81,7 +81,7 @@ unique_ptr<GlobalMetadata> NvmeFileSystemProxy::LoadMetadata(optional_ptr<FileOp
 	}
 
 	unique_ptr<GlobalMetadata> global = make_uniq<GlobalMetadata>(GlobalMetadata {});
-	memcpy(&global, (buffer + sizeof(MAGIC_BYTES)), sizeof(GlobalMetadata));
+	memcpy(global.get(), (buffer + sizeof(MAGIC_BYTES)), sizeof(GlobalMetadata));
 
 	allocator.FreeData(buffer, bytes_to_read);
 
@@ -125,7 +125,7 @@ void NvmeFileSystemProxy::WriteMetadata(uint64_t location, uint64_t nr_lbas, Met
 		data_ptr_t buffer = allocator.AllocateData(bytes_to_write);
 
 		memcpy(buffer, MAGIC_BYTES, sizeof(MAGIC_BYTES));
-		memcpy(buffer + sizeof(MAGIC_BYTES), &metadata, sizeof(GlobalMetadata));
+		memcpy(buffer + sizeof(MAGIC_BYTES), metadata.get(), sizeof(GlobalMetadata));
 
 		FileOpenFlags flags = FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE;
 

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -237,7 +237,7 @@ unique_ptr<GlobalMetadata> NvmeFileSystemProxy::InitializeMetadata(optional_ptr<
 	global->write_ahead_log = meta_wal;
 
 	memcpy(buffer, MAGIC_BYTES, sizeof(MAGIC_BYTES));
-	memcpy(buffer + sizeof(MAGIC_BYTES), &global, sizeof(GlobalMetadata));
+	memcpy(buffer + sizeof(MAGIC_BYTES), global.get(), sizeof(GlobalMetadata));
 
 	FileOpenFlags flags = FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE;
 

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -253,7 +253,12 @@ int64_t NvmeFileSystemProxy::Read(FileHandle &handle, void *buffer, int64_t nr_b
 	MetadataType meta_type = GetMetadataType(handle.path);
 	uint64_t lba_start_location = GetStartLBA(meta_type, handle.path);
 
-	fs->Read(handle, buffer, nr_bytes, lba_start_location);
+	data_ptr_t temp_buf = allocator.AllocateData(nr_bytes);
+
+	fs->Read(handle, temp_buf, nr_bytes, lba_start_location);
+
+	memcpy(buffer, temp_buf, nr_bytes);
+	allocator.FreeData(temp_buf, nr_bytes);
 
 	return nr_bytes;
 }

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -152,6 +152,31 @@ MetadataType NvmeFileSystemProxy::GetMetadataType(string path){
 	}
 }
 
+uint64_t NvmeFileSystemProxy::GetStartLBA(MetadataType type, string filename) {
+	uint64_t lba {};
+
+	switch (type) {
+	case MetadataType::WAL:
+		// TODO: Alignment???
+		lba = metadata->write_ahead_log.start;
+		break;
+	case MetadataType::TEMPORARY:
+		if (file_to_lba.count(filename)) {
+			lba = file_to_lba[filename];
+		} else {
+			lba = metadata->temporary.start;
+		}
+		break;
+	case MetadataType::DATABASE:
+		lba = metadata->database.start;
+		break;
+	default:
+		throw InvalidInputException("no such metadatatype");
+	}
+
+	return lba;
+}
+
 uint64_t NvmeFileSystemProxy::GetLBA(MetadataType type, string filename, idx_t location) {
 	// TODO: for WAL and temp ensure that it can fit in range
 	// otherwise increase size + update mapping to temp files for temp type

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -163,7 +163,7 @@ uint64_t NvmeFileSystemProxy::GetStartLBA(MetadataType type, string filename) {
 		if (file_to_lba.count(filename)) {
 			lba = file_to_lba[filename];
 		} else {
-			lba = metadata->temporary.start;
+			lba = metadata->temporary.location;
 		}
 		break;
 	case MetadataType::DATABASE:


### PR DESCRIPTION

# What was the issue?

When DuckDB internally called the Read and Write functions without a location in the function signature then we just used `0`. This is wrong since it will overwrite our metadata.

## How was it fixed?

By using the same strategy as `GetLBA()` we have created a new function that gets the start of the category, `GetStartLBA()`.

### Commits

- **Remove unused read and write methods**
- **Implement GetStartLBA() to return the start LBA of the section**
- **Implement the fix to set the correct LBA to read from**
- **Add missing argument to FileHandle construction**
- **Use underlying pointer instead of ref to pointer**
- **Change the temp to use location if the file does not exist**
- **USe underlying pointer for metadata**
- **Try add allocator**
