### PR TITLE
Add implementation of Sync and filesync

### DIFF
--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -33,6 +33,7 @@ public:
 	int64_t Read(void *buffer, idx_t nr_bytes);
 	int64_t Write(void *buffer, idx_t nr_bytes);
 	idx_t GetFileSize();
+	void Sync();
 
 protected:
 	unique_ptr<NvmeCmdContext> PrepareWriteCommand(int64_t nr_bytes);

--- a/src/include/nvmefs_proxy.hpp
+++ b/src/include/nvmefs_proxy.hpp
@@ -59,6 +59,7 @@ public:
 	bool CanHandleFile(const string &fpath) override;
 	bool FileExists(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
 	int64_t GetFileSize(FileHandle &handle) override;
+	void FileSync(FileHandle &handle) override;
 
 	string GetName() const {
 		return "NvmeFileSystemProxy";

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -57,6 +57,10 @@ idx_t NvmeFileHandle::GetFileSize() {
 	return file_system.GetFileSize(*this);
 }
 
+void NvmeFileHandle::Sync() {
+	file_system.FileSync(*this);
+}
+
 /// @brief Calculates the amount of LBAs required to store the given number of bytes
 /// @param lba_size The size of a single LBA
 /// @param nr_bytes The number of bytes to store

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -110,7 +110,7 @@ bool NvmeFileSystemProxy::FileExists(const string &filename, optional_ptr<FileOp
 	string db_path_no_ext = StringUtil::GetFileStem(metadata->db_path);
 
 	switch (type) {
-      
+
 	case WAL:
 		/*
 		    Intentional fall-through. Need to remove the '.wal' and db ext
@@ -375,6 +375,10 @@ int64_t NvmeFileSystemProxy::GetFileSize(FileHandle &handle) {
 
 	return (location_lba - start_lba) *
 	       NVME_BLOCK_SIZE; // TODO: NVME_BLOCK_SIZE should be changed. We should get it from the filehandle
+}
+
+void NvmeFileSystemProxy::FileSync(FileHandle &handle) {
+	// This should just be empty. We do not need to sync to disk since we write directly to disk
 }
 
 } // namespace duckdb


### PR DESCRIPTION

# What does this PR implement?

Since DuckDB uses `fsync` to ensure that the data that is written is being flushed to disk then we also had to implement our version of this function in our file system that DuckDB is depending upon. 

The implementation is pretty simple. It is empty. We write directly to the device, so we do not have to implement anything to make sure that it has been written. Additionally we synchronous calls to the device. This means that when the call returns successfully then it is written to disk.
