### PR TITLE
Fix the lba amount being provided to the xnvme command

### DIFF
--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -194,8 +194,12 @@ uint8_t NvmeFileSystem::GetPlacementIdentifierIndexOrDefault(const string &path)
 
 void NvmeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	NvmeFileHandle &nvme_handle = handle.Cast<NvmeFileHandle>();
-	unique_ptr<NvmeCmdContext> nvme_ctx = nvme_handle.PrepareReadCommand(nr_bytes);
 
+	if (nr_bytes <= 4096) {
+		nr_bytes = 4096 * 2;
+	}
+
+	unique_ptr<NvmeCmdContext> nvme_ctx = nvme_handle.PrepareReadCommand(nr_bytes);
 	nvme_buf_ptr dev_buffer = nvme_handle.AllocateDeviceBuffer(nr_bytes);
 
 	int err =
@@ -216,6 +220,11 @@ void NvmeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, i
 
 uint64_t NvmeFileSystem::WriteInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	NvmeFileHandle &nvme_handle = handle.Cast<NvmeFileHandle>();
+
+	if (nr_bytes <= 4096) {
+		nr_bytes = 4096 * 2;
+	}
+
 	unique_ptr<NvmeCmdContext> nvme_ctx = nvme_handle.PrepareWriteCommand(nr_bytes);
 
 	nvme_buf_ptr dev_buffer = nvme_handle.AllocateDeviceBuffer(nr_bytes);

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -200,8 +200,8 @@ void NvmeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 
 	nvme_buf_ptr dev_buffer = nvme_handle.AllocateDeviceBuffer(nr_bytes);
 
-	int err =
-	    xnvme_nvm_read(&nvme_ctx->ctx, nvme_ctx->namespace_id, location, nvme_ctx->number_of_lbas - 1, buffer, nullptr);
+	int err = xnvme_nvm_read(&nvme_ctx->ctx, nvme_ctx->namespace_id, location, nvme_ctx->number_of_lbas - 1, dev_buffer,
+	                         nullptr);
 	if (err) {
 		// TODO: Handle error
 		throw IOException("Error reading from NVMe device");
@@ -225,8 +225,8 @@ uint64_t NvmeFileSystem::WriteInternal(FileHandle &handle, void *buffer, int64_t
 	nvme_buf_ptr dev_buffer = nvme_handle.AllocateDeviceBuffer(nr_bytes);
 	memcpy(dev_buffer, buffer, nr_bytes);
 
-	int err = xnvme_nvm_write(&nvme_ctx->ctx, nvme_ctx->namespace_id, location, nvme_ctx->number_of_lbas - 1, buffer,
-	                          nullptr);
+	int err = xnvme_nvm_write(&nvme_ctx->ctx, nvme_ctx->namespace_id, location, nvme_ctx->number_of_lbas - 1,
+	                          dev_buffer, nullptr);
 	if (err) {
 		// TODO: Handle error
 		xnvme_cli_perr("xnvme_nvm_write()", err);

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -196,7 +196,7 @@ void NvmeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 	NvmeFileHandle &nvme_handle = handle.Cast<NvmeFileHandle>();
 
 	if (nr_bytes <= 4096) {
-		nr_bytes = 4096 * 2;
+		nr_bytes = 4096 * 64;
 	}
 
 	unique_ptr<NvmeCmdContext> nvme_ctx = nvme_handle.PrepareReadCommand(nr_bytes);
@@ -222,7 +222,7 @@ uint64_t NvmeFileSystem::WriteInternal(FileHandle &handle, void *buffer, int64_t
 	NvmeFileHandle &nvme_handle = handle.Cast<NvmeFileHandle>();
 
 	if (nr_bytes <= 4096) {
-		nr_bytes = 4096 * 2;
+		nr_bytes = 4096 * 64;
 	}
 
 	unique_ptr<NvmeCmdContext> nvme_ctx = nvme_handle.PrepareWriteCommand(nr_bytes);

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -226,6 +226,7 @@ uint64_t NvmeFileSystem::WriteInternal(FileHandle &handle, void *buffer, int64_t
 	    xnvme_nvm_write(&nvme_ctx->ctx, nvme_ctx->namespace_id, location, nvme_ctx->number_of_lbas, buffer, nullptr);
 	if (err) {
 		// TODO: Handle error
+		xnvme_cli_perr("xnvme_nvm_write()", err);
 		throw IOException("Error writing to NVMe device");
 	}
 

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -195,10 +195,6 @@ uint8_t NvmeFileSystem::GetPlacementIdentifierIndexOrDefault(const string &path)
 void NvmeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	NvmeFileHandle &nvme_handle = handle.Cast<NvmeFileHandle>();
 
-	if (nr_bytes <= 4096) {
-		nr_bytes = 4096 * 64;
-	}
-
 	unique_ptr<NvmeCmdContext> nvme_ctx = nvme_handle.PrepareReadCommand(nr_bytes);
 	nvme_buf_ptr dev_buffer = nvme_handle.AllocateDeviceBuffer(nr_bytes);
 
@@ -220,10 +216,6 @@ void NvmeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, i
 
 uint64_t NvmeFileSystem::WriteInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	NvmeFileHandle &nvme_handle = handle.Cast<NvmeFileHandle>();
-
-	if (nr_bytes <= 4096) {
-		nr_bytes = 4096 * 64;
-	}
 
 	unique_ptr<NvmeCmdContext> nvme_ctx = nvme_handle.PrepareWriteCommand(nr_bytes);
 

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -212,7 +212,7 @@ unique_ptr<GlobalMetadata> NvmeFileSystemProxy::ReadMetadata(FileHandle &handle)
 
 	fs->Read(*fh, buffer, bytes_to_read, NVMEFS_METADATA_LOCATION);
 
-	unique_ptr<GlobalMetadata> global = make_uniq<GlobalMetadata>();
+	unique_ptr<GlobalMetadata> global = nullptr;
 
 	// Check magic bytes
 	if (memcmp(buffer, MAGIC_BYTES, sizeof(MAGIC_BYTES)) == 0) {


### PR DESCRIPTION

- **Print the cli err code when write goes wrong**
- **Force to write to two lbas at least**
- **Read and write to 64 lbas each time**
- **Remove test code**
- **Make the lba count account for zero index when using the nvm_write and read command**
- **Simplify if statements for metadata loading**
- **Use device buffer**
- **Init global as nullptr**
