### PR TITLE
Add in-block reading of data

### DIFF
--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -80,7 +80,7 @@ public:
 
 protected:
 	uint8_t GetPlacementIdentifierIndexOrDefault(const string &path);
-	uint64_t WriteInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);
+	uint64_t WriteInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location_lba);
 
 	/// @brief Opens a file handle for metadata in the context of a given file handle
 	/// @param handle The file handle to get context from

--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -81,6 +81,8 @@ public:
 protected:
 	uint8_t GetPlacementIdentifierIndexOrDefault(const string &path);
 	uint64_t WriteInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location_lba);
+	uint64_t ReadInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location_lba,
+	                      idx_t in_block_offset);
 
 	/// @brief Opens a file handle for metadata in the context of a given file handle
 	/// @param handle The file handle to get context from

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -216,7 +216,7 @@ void NvmeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, i
 	WriteInternal(handle, buffer, nr_bytes, location);
 }
 
-uint64_t NvmeFileSystem::WriteInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+uint64_t NvmeFileSystem::WriteInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location_lba) {
 	NvmeFileHandle &nvme_handle = handle.Cast<NvmeFileHandle>();
 
 	unique_ptr<NvmeCmdContext> nvme_ctx = nvme_handle.PrepareWriteCommand(nr_bytes);
@@ -225,7 +225,7 @@ uint64_t NvmeFileSystem::WriteInternal(FileHandle &handle, void *buffer, int64_t
 	nvme_buf_ptr dev_buffer = nvme_handle.AllocateDeviceBuffer(nr_bytes);
 	memcpy(dev_buffer, buffer, nr_bytes);
 
-	int err = xnvme_nvm_write(&nvme_ctx->ctx, nvme_ctx->namespace_id, location, nvme_ctx->number_of_lbas - 1,
+	int err = xnvme_nvm_write(&nvme_ctx->ctx, nvme_ctx->namespace_id, location_lba, nvme_ctx->number_of_lbas - 1,
 	                          dev_buffer, nullptr);
 	if (err) {
 		// TODO: Handle error

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -54,7 +54,10 @@ void NvmeFileSystemProxy::Read(FileHandle &handle, void *buffer, int64_t nr_byte
 	MetadataType type = GetMetadataType(handle.path);
 	uint64_t lba_start_location = GetLBA(type, handle.path, location);
 
-	fs->Read(handle, buffer, nr_bytes, lba_start_location);
+	// Get the offset of bytes within the block
+	int16_t in_block_offset = location % NVME_BLOCK_SIZE;
+
+	fs->ReadInternal(handle, buffer, nr_bytes, lba_start_location, in_block_offset);
 }
 
 void NvmeFileSystemProxy::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {


### PR DESCRIPTION

This pr adds the possibility to read inside a block and return that data. This is especially used for the DuckDB header when checking the version and magic bytes, before DuckDB can be sure that it is a DuckDB database file.

#### Commits
- **Change name of location in InternalWrite**
- **Implement ReadInternal**
- **Calculate in block offset and use ReadInternal**
