### PR TITLE
Implement dynamic calculation of lba ranges for categories of data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ testext
 test/python/__pycache__/
 .Rhistory
 .vscode
+**/.venv

--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -98,7 +98,7 @@ public:
 	}
 
 protected:
-	NvmeDeviceGeometry GetDeviceGeometry();
+	shared_ptr<NvmeDeviceGeometry> GetDeviceGeometry();
 	uint8_t GetPlacementIdentifierIndexOrDefault(const string &path);
 	uint64_t WriteInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location_lba,
 	                       idx_t in_block_offset);
@@ -114,6 +114,7 @@ protected:
 private:
 	map<string, uint8_t> allocated_placement_identifiers;
 	vector<string> allocated_paths;
+	shared_ptr<NvmeDeviceGeometry> geometry;
 	NvmeFileSystemProxy &proxy_filesystem;
 	string device_path;
 	uint64_t plhdls;

--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -98,7 +98,7 @@ public:
 	}
 
 protected:
-	shared_ptr<NvmeDeviceGeometry> GetDeviceGeometry();
+	unique_ptr<NvmeDeviceGeometry> GetDeviceGeometry();
 	uint8_t GetPlacementIdentifierIndexOrDefault(const string &path);
 	uint64_t WriteInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location_lba,
 	                       idx_t in_block_offset);
@@ -114,7 +114,6 @@ protected:
 private:
 	map<string, uint8_t> allocated_placement_identifiers;
 	vector<string> allocated_paths;
-	shared_ptr<NvmeDeviceGeometry> geometry;
 	NvmeFileSystemProxy &proxy_filesystem;
 	string device_path;
 	uint64_t plhdls;

--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -16,6 +16,11 @@ struct NvmeCmdContext {
 	uint64_t number_of_lbas;
 };
 
+struct NvmeDeviceGeometry {
+	uint64_t lba_size;
+	uint64_t lba_count;
+};
+
 typedef void *nvme_buf_ptr;
 
 class NvmeFileHandle;
@@ -93,6 +98,7 @@ public:
 	}
 
 protected:
+	NvmeDeviceGeometry GetDeviceGeometry();
 	uint8_t GetPlacementIdentifierIndexOrDefault(const string &path);
 	uint64_t WriteInternal(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location_lba,
 	                       idx_t in_block_offset);

--- a/src/include/nvmefs_proxy.hpp
+++ b/src/include/nvmefs_proxy.hpp
@@ -43,6 +43,7 @@ struct TemporaryFileMetadata {
 
 class NvmeFileSystem;
 class NvmeFileHandle;
+struct NvmeDeviceGeometry;
 typedef NvmeFileHandle MetadataFileHandle;
 
 class NvmeFileSystemProxy : public FileSystem {

--- a/src/include/nvmefs_proxy.hpp
+++ b/src/include/nvmefs_proxy.hpp
@@ -96,6 +96,7 @@ private:
 
 	// Metadata of the filesystem present in the device
 	unique_ptr<GlobalMetadata> metadata;
+	NvmeDeviceGeometry geometry;
 	unique_ptr<NvmeFileSystem> fs;
 	map<std::string, TemporaryFileMetadata> file_to_lba;
 	uint64_t max_temp_size;

--- a/src/include/nvmefs_proxy.hpp
+++ b/src/include/nvmefs_proxy.hpp
@@ -89,18 +89,14 @@ private:
 private:
 	Allocator &allocator;
 
-	// Maximum storage for temporary files in bytes
-	idx_t maximum_temp_storage;
-
-	// Maximum storage for write ahead log in bytes
-	idx_t maximum_wal_storage;
-
 	// Metadata of the filesystem present in the device
 	unique_ptr<GlobalMetadata> metadata;
 	unique_ptr<NvmeDeviceGeometry> geometry;
 	unique_ptr<NvmeFileSystem> fs;
 	map<std::string, TemporaryFileMetadata> file_to_lba;
+	// Maximum storage for temporary files in bytes
 	uint64_t max_temp_size;
+	// Maximum storage for write ahead log in bytes
 	uint64_t max_wal_size;
 };
 

--- a/src/include/nvmefs_proxy.hpp
+++ b/src/include/nvmefs_proxy.hpp
@@ -97,7 +97,7 @@ private:
 
 	// Metadata of the filesystem present in the device
 	unique_ptr<GlobalMetadata> metadata;
-	NvmeDeviceGeometry geometry;
+	unique_ptr<NvmeDeviceGeometry> geometry;
 	unique_ptr<NvmeFileSystem> fs;
 	map<std::string, TemporaryFileMetadata> file_to_lba;
 	uint64_t max_temp_size;

--- a/src/include/nvmefs_proxy.hpp
+++ b/src/include/nvmefs_proxy.hpp
@@ -97,7 +97,7 @@ private:
 
 	// Metadata of the filesystem present in the device
 	unique_ptr<GlobalMetadata> metadata;
-	unique_ptr<NvmeDeviceGeometry> geometry;
+	shared_ptr<NvmeDeviceGeometry> geometry;
 	unique_ptr<NvmeFileSystem> fs;
 	map<std::string, TemporaryFileMetadata> file_to_lba;
 	uint64_t max_temp_size;

--- a/src/include/nvmefs_proxy.hpp
+++ b/src/include/nvmefs_proxy.hpp
@@ -97,7 +97,7 @@ private:
 
 	// Metadata of the filesystem present in the device
 	unique_ptr<GlobalMetadata> metadata;
-	shared_ptr<NvmeDeviceGeometry> geometry;
+	unique_ptr<NvmeDeviceGeometry> geometry;
 	unique_ptr<NvmeFileSystem> fs;
 	map<std::string, TemporaryFileMetadata> file_to_lba;
 	uint64_t max_temp_size;

--- a/src/include/nvmefs_proxy.hpp
+++ b/src/include/nvmefs_proxy.hpp
@@ -25,16 +25,10 @@ struct Metadata {
 	uint64_t start;
 	uint64_t end;
 	uint64_t location;
-
-	// db_end
-	// start end -> tmp wal
-	// tmp_head wal_head
-	// mapping fil -> (start, størrelse)
 };
 
 struct GlobalMetadata {
 	uint64_t db_path_size;
-	// TODO: use string instead
 	char db_path[101];
 
 	Metadata database;
@@ -93,6 +87,14 @@ private:
 
 private:
 	Allocator &allocator;
+
+	// Maximum storage for temporary files in bytes
+	idx_t maximum_temp_storage;
+
+	// Maximum storage for write ahead log in bytes
+	idx_t maximum_wal_storage;
+
+	// Metadata of the filesystem present in the device
 	unique_ptr<GlobalMetadata> metadata;
 	unique_ptr<NvmeFileSystem> fs;
 	map<std::string, TemporaryFileMetadata> file_to_lba;

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -268,15 +268,11 @@ idx_t NvmeFileSystem::SeekPosition(FileHandle &handle) {
 	return handle.Cast<NvmeFileHandle>().GetFilePointer();
 }
 
-shared_ptr<NvmeDeviceGeometry> NvmeFileSystem::GetDeviceGeometry() {
-
-	if (geometry) {
-		return geometry;
-	}
+unique_ptr<NvmeDeviceGeometry> NvmeFileSystem::GetDeviceGeometry() {
 
 	xnvme_dev *device = xnvme_dev_open(device_path.c_str(), nullptr);
 
-	NvmeDeviceGeometry *device_geo = new NvmeDeviceGeometry();
+	unique_ptr<NvmeDeviceGeometry> device_geo = make_uniq<NvmeDeviceGeometry>(NvmeDeviceGeometry {});
 	const xnvme_geo *geo = xnvme_dev_get_geo(device);
 	const xnvme_spec_idfy_ns *nsgeo = xnvme_dev_get_ns(device);
 
@@ -285,6 +281,6 @@ shared_ptr<NvmeDeviceGeometry> NvmeFileSystem::GetDeviceGeometry() {
 
 	xnvme_dev_close(device);
 
-	return unique_ptr<NvmeDeviceGeometry>(device_geo);
+	return move(device_geo);
 }
 } // namespace duckdb

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -274,13 +274,10 @@ NvmeDeviceGeometry NvmeFileSystem::GetDeviceGeometry() {
 
 	NvmeDeviceGeometry geometry;
 	const xnvme_geo *geo = xnvme_dev_get_geo(device);
+	const xnvme_spec_idfy_ns *nsgeo = xnvme_dev_get_ns(device);
 
 	geometry.lba_size = geo->lba_nbytes;
-	geometry.lba_count = geo->tbytes / geo->lba_nbytes;
-
-	uint32_t nsid = xnvme_dev_get_nsid(device);
-	const xnvme_spec_idfy_ns *nsgeo = xnvme_dev_get_ns(device);
-	// Look at the ncap and nsze fields in nsgeo to get the number of LBAs in the namespace
+	geometry.lba_count = nsgeo->nsze;
 
 	xnvme_dev_close(device);
 

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -268,19 +268,23 @@ idx_t NvmeFileSystem::SeekPosition(FileHandle &handle) {
 	return handle.Cast<NvmeFileHandle>().GetFilePointer();
 }
 
-NvmeDeviceGeometry NvmeFileSystem::GetDeviceGeometry() {
+shared_ptr<NvmeDeviceGeometry> NvmeFileSystem::GetDeviceGeometry() {
+
+	if (geometry) {
+		return geometry;
+	}
 
 	xnvme_dev *device = xnvme_dev_open(device_path.c_str(), nullptr);
 
-	NvmeDeviceGeometry geometry;
+	NvmeDeviceGeometry *device_geo = new NvmeDeviceGeometry();
 	const xnvme_geo *geo = xnvme_dev_get_geo(device);
 	const xnvme_spec_idfy_ns *nsgeo = xnvme_dev_get_ns(device);
 
-	geometry.lba_size = geo->lba_nbytes;
-	geometry.lba_count = nsgeo->nsze;
+	device_geo->lba_size = geo->lba_nbytes;
+	device_geo->lba_count = nsgeo->nsze;
 
 	xnvme_dev_close(device);
 
-	return geometry;
+	return unique_ptr<NvmeDeviceGeometry>(device_geo);
 }
 } // namespace duckdb

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -282,5 +282,5 @@ NvmeDeviceGeometry NvmeFileSystem::GetDeviceGeometry() {
 	xnvme_dev_close(device);
 
 	return geometry;
-
+}
 } // namespace duckdb

--- a/src/nvmefs_config.cpp
+++ b/src/nvmefs_config.cpp
@@ -55,10 +55,12 @@ NvmeConfig NvmeConfigManager::LoadConfig(DatabaseInstance &instance) {
 
 	string device;
 	int64_t plhdls = 0;
-	//TODO: ensure that we always have value here. It is possible to not have value
-	uint64_t max_temp_size = static_cast<uint64_t>(config.options.maximum_swap_space);
-	uint64_t max_wal_size = 2^25; // 32 MiB
-
+	// TODO: ensure that we always have value here. It is possible to not have value
+	uint64_t max_temp_size = 2 ^ 30; // 1 GiB
+	if (config.options.maximum_swap_space != DConstants::INVALID_INDEX) {
+		max_temp_size = static_cast<uint64_t>(config.options.maximum_swap_space);
+	}
+	uint64_t max_wal_size = 2 ^ 25; // 32 MiB
 
 	secret_reader.TryGetSecretKeyOrSetting<string>("nvme_device_path", "nvme_device_path", device);
 	secret_reader.TryGetSecretKeyOrSetting<int64_t>("fdp_plhdls", "fdp_plhdls", plhdls);
@@ -67,8 +69,9 @@ NvmeConfig NvmeConfigManager::LoadConfig(DatabaseInstance &instance) {
 	config.AddExtensionOption("fdp_plhdls", "Amount of available placement handlers on the device",
 	                          {LogicalType::BIGINT}, Value(plhdls));
 
-
-	return NvmeConfig{.device_path=device, .plhdls=static_cast<uint64_t>(plhdls), .max_temp_size=max_temp_size, .max_wal_size=max_wal_size};
-
+	return NvmeConfig {.device_path = device,
+	                   .plhdls = static_cast<uint64_t>(plhdls),
+	                   .max_temp_size = max_temp_size,
+	                   .max_wal_size = max_wal_size};
 }
 } // namespace duckdb

--- a/src/nvmefs_config.cpp
+++ b/src/nvmefs_config.cpp
@@ -56,11 +56,11 @@ NvmeConfig NvmeConfigManager::LoadConfig(DatabaseInstance &instance) {
 	string device;
 	int64_t plhdls = 0;
 	// TODO: ensure that we always have value here. It is possible to not have value
-	uint64_t max_temp_size = 2 ^ 30; // 1 GiB
+	uint64_t max_temp_size = 1ULL << 30; // 1 GiB
 	if (config.options.maximum_swap_space != DConstants::INVALID_INDEX) {
 		max_temp_size = static_cast<uint64_t>(config.options.maximum_swap_space);
 	}
-	uint64_t max_wal_size = 2 ^ 25; // 32 MiB
+	uint64_t max_wal_size = 1ULL << 25; // 32 MiB
 
 	secret_reader.TryGetSecretKeyOrSetting<string>("nvme_device_path", "nvme_device_path", device);
 	secret_reader.TryGetSecretKeyOrSetting<int64_t>("fdp_plhdls", "fdp_plhdls", plhdls);

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -37,7 +37,8 @@ NvmeFileSystemProxy::NvmeFileSystemProxy()
 }
 
 NvmeFileSystemProxy::NvmeFileSystemProxy(NvmeConfig config)
-    : fs(make_uniq<NvmeFileSystem>(*this, config.device_path, config.plhdls)), allocator(Allocator::DefaultAllocator()), max_temp_size(config.max_temp_size), max_wal_size(config.max_wal_size), geometry(fs->GetDeviceGeometry()) {
+    : fs(make_uniq<NvmeFileSystem>(*this, config.device_path, config.plhdls)), allocator(Allocator::DefaultAllocator()),
+      max_temp_size(config.max_temp_size), max_wal_size(config.max_wal_size), geometry(&fs->GetDeviceGeometry()) {
 }
 
 unique_ptr<FileHandle> NvmeFileSystemProxy::OpenFile(const string &path, FileOpenFlags flags,
@@ -193,12 +194,12 @@ void NvmeFileSystemProxy::InitializeMetadata(FileHandle &handle, string path) {
 	// Example:
 	//  1 GB temp data -> x files -> map that supports x files total (this is the size)
 
-	uint64_t temp_start = (geometry.lba_count - 1) - (maximum_temp_storage / geometry.lba_size);
+	uint64_t temp_start = (geometry->lba_count - 1) - (maximum_temp_storage / geometry->lba_size);
 
-	uint64_t wal_lba_count = maximum_wal_storage / geometry.lba_size;
+	uint64_t wal_lba_count = maximum_wal_storage / geometry->lba_size;
 	uint64_t wal_start = (temp_start - 1) - maximum_wal_storage;
 
-	Metadata meta_temp {.start = temp_start, .end = geometry.lba_count - 1, .location = temp_start};
+	Metadata meta_temp {.start = temp_start, .end = geometry->lba_count - 1, .location = temp_start};
 	Metadata meta_wal {.start = wal_start, .end = temp_start - 1, .location = wal_start};
 	Metadata meta_db {.start = 1,
 	                  .end = wal_start - 1,

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -195,10 +195,10 @@ void NvmeFileSystemProxy::InitializeMetadata(FileHandle &handle, string path) {
 	// Example:
 	//  1 GB temp data -> x files -> map that supports x files total (this is the size)
 
-	uint64_t temp_start = (geometry->lba_count - 1) - (maximum_temp_storage / geometry->lba_size);
+	uint64_t temp_start = (geometry->lba_count - 1) - (max_temp_size / geometry->lba_size);
 
-	uint64_t wal_lba_count = maximum_wal_storage / geometry->lba_size;
-	uint64_t wal_start = (temp_start - 1) - maximum_wal_storage;
+	uint64_t wal_lba_count = max_wal_size / geometry->lba_size;
+	uint64_t wal_start = (temp_start - 1) - max_wal_size;
 
 	Metadata meta_temp {.start = temp_start, .end = geometry->lba_count - 1, .location = temp_start};
 	Metadata meta_wal {.start = wal_start, .end = temp_start - 1, .location = wal_start};

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -194,14 +194,16 @@ void NvmeFileSystemProxy::InitializeMetadata(FileHandle &handle, string path) {
 
 	NvmeDeviceGeometry geometry = fs->GetDeviceGeometry();
 	uint64_t temp_start = (geometry.lba_count - 1) - 2 ^ 30 / geometry.lba_size;
-	uint64_t wal_checkpoint_size = 2 ^ 24;
+
 	uint64_t wal_size = 2 ^ 24 * 2; // 16 MiB * 2
 	uint64_t wal_lba_count = wal_size / geometry.lba_size;
 	uint64_t wal_start = (temp_start - 1) - wal_size;
 
 	Metadata meta_temp {.start = temp_start, .end = geometry.lba_count - 1, .location = temp_start};
 	Metadata meta_wal {.start = wal_start, .end = temp_start - 1, .location = wal_start};
-	Metadata meta_db {.start = 1, .end = wal_start - 1, .location = 1};
+	Metadata meta_db {.start = 1,
+	                  .end = wal_start - 1,
+	                  .location = 1}; // 1 is the first lba due to lba 0 being allocated for device metadata
 
 	unique_ptr<GlobalMetadata> global = make_uniq<GlobalMetadata>(GlobalMetadata {});
 

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -38,7 +38,7 @@ NvmeFileSystemProxy::NvmeFileSystemProxy()
 
 NvmeFileSystemProxy::NvmeFileSystemProxy(NvmeConfig config)
     : fs(make_uniq<NvmeFileSystem>(*this, config.device_path, config.plhdls)), allocator(Allocator::DefaultAllocator()),
-      max_temp_size(config.max_temp_size), max_wal_size(config.max_wal_size), geometry(&fs->GetDeviceGeometry()) {
+      max_temp_size(config.max_temp_size), max_wal_size(config.max_wal_size), geometry(fs->GetDeviceGeometry()) {
 }
 
 unique_ptr<FileHandle> NvmeFileSystemProxy::OpenFile(const string &path, FileOpenFlags flags,

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -193,11 +193,10 @@ void NvmeFileSystemProxy::InitializeMetadata(FileHandle &handle, string path) {
 	//  1 GB temp data -> x files -> map that supports x files total (this is the size)
 
 	NvmeDeviceGeometry geometry = fs->GetDeviceGeometry();
-	uint64_t temp_start = (geometry.lba_count - 1) - 2 ^ 30 / geometry.lba_size;
+	uint64_t temp_start = (geometry.lba_count - 1) - (maximum_temp_storage / geometry.lba_size);
 
-	uint64_t wal_size = 2 ^ 24 * 2; // 16 MiB * 2
-	uint64_t wal_lba_count = wal_size / geometry.lba_size;
-	uint64_t wal_start = (temp_start - 1) - wal_size;
+	uint64_t wal_lba_count = maximum_wal_storage / geometry.lba_size;
+	uint64_t wal_start = (temp_start - 1) - maximum_wal_storage;
 
 	Metadata meta_temp {.start = temp_start, .end = geometry.lba_count - 1, .location = temp_start};
 	Metadata meta_wal {.start = wal_start, .end = temp_start - 1, .location = wal_start};

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -31,12 +31,13 @@ void PrintFullMetadata(GlobalMetadata &metadata) {
 }
 #endif
 
+// TODO: Should this constructor be removed?
 NvmeFileSystemProxy::NvmeFileSystemProxy()
     : fs(make_uniq<NvmeFileSystem>(*this)), allocator(Allocator::DefaultAllocator()) {
 }
 
 NvmeFileSystemProxy::NvmeFileSystemProxy(NvmeConfig config)
-    : fs(make_uniq<NvmeFileSystem>(*this, config.device_path, config.plhdls)), allocator(Allocator::DefaultAllocator()), max_temp_size(config.max_temp_size), max_wal_size(config.max_wal_size) {
+    : fs(make_uniq<NvmeFileSystem>(*this, config.device_path, config.plhdls)), allocator(Allocator::DefaultAllocator()), max_temp_size(config.max_temp_size), max_wal_size(config.max_wal_size), geometry(fs->GetDeviceGeometry()) {
 }
 
 unique_ptr<FileHandle> NvmeFileSystemProxy::OpenFile(const string &path, FileOpenFlags flags,
@@ -192,7 +193,6 @@ void NvmeFileSystemProxy::InitializeMetadata(FileHandle &handle, string path) {
 	// Example:
 	//  1 GB temp data -> x files -> map that supports x files total (this is the size)
 
-	NvmeDeviceGeometry geometry = fs->GetDeviceGeometry();
 	uint64_t temp_start = (geometry.lba_count - 1) - (maximum_temp_storage / geometry.lba_size);
 
 	uint64_t wal_lba_count = maximum_wal_storage / geometry.lba_size;

--- a/src/nvmefs_proxy.cpp
+++ b/src/nvmefs_proxy.cpp
@@ -38,7 +38,8 @@ NvmeFileSystemProxy::NvmeFileSystemProxy()
 
 NvmeFileSystemProxy::NvmeFileSystemProxy(NvmeConfig config)
     : fs(make_uniq<NvmeFileSystem>(*this, config.device_path, config.plhdls)), allocator(Allocator::DefaultAllocator()),
-      max_temp_size(config.max_temp_size), max_wal_size(config.max_wal_size), geometry(fs->GetDeviceGeometry()) {
+      max_temp_size(config.max_temp_size), max_wal_size(config.max_wal_size) {
+	geometry = fs->GetDeviceGeometry();
 }
 
 unique_ptr<FileHandle> NvmeFileSystemProxy::OpenFile(const string &path, FileOpenFlags flags,


### PR DESCRIPTION
# What is implemented?

Previously we had a hard coded range of Logical Block Addresses (LBA) defined for our three categories of data that we store on disk(i.e. Database, Write Ahead Log(WAL), and temporary data). Now we calculate it based on the settings from DuckDB and the device geometry.

Here is an example of what the values are when running on the server:
<img width="356" alt="image" src="https://github.com/user-attachments/assets/9b6f4ae0-9a81-47fb-b9d9-a866bad158fb" />

