### PR TITLE
Implement fake device

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(EXTENSION_SOURCES
   src/nvmefs.cpp
   src/nvmefs_config.cpp
   src/device.cpp
+  src/fake_device.cpp
   src/nvme_device.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})

--- a/src/fake_device.cpp
+++ b/src/fake_device.cpp
@@ -1,0 +1,22 @@
+#include "fake_device.hpp"
+
+namespace duckdb {
+FakeDevice::FakeDevice(idx_t lba_count, idx_t lba_size) : Device(), geometry(DeviceGeometry {lba_count, lba_size}) {
+	vector<uint8_t> data(lba_count * lba_size);
+}
+
+FakeDevice::~FakeDevice() {
+}
+
+idx_t FakeDevice::Write(void *buffer, idx_t nr_bytes, idx_t nr_lba, idx_t start_lba, idx_t offset) {
+	return nr_lba;
+}
+
+idx_t FakeDevice::Read(void *buffer, idx_t nr_bytes, idx_t nr_lba, idx_t start_lba, idx_t offset) {
+	return nr_lba;
+}
+
+DeviceGeometry FakeDevice::GetDeviceGeometry() {
+	return geometry;
+}
+} // namespace duckdb

--- a/src/fake_device.cpp
+++ b/src/fake_device.cpp
@@ -8,7 +8,7 @@ FakeDevice::FakeDevice(idx_t lba_count, idx_t lba_size)
 FakeDevice::~FakeDevice() {
 }
 
-idx_t FakeDevice::Write(void *buffer, CmdContext context) {
+idx_t FakeDevice::Write(void *buffer, const CmdContext &context) {
 	D_ASSERT(context.start_lba + context.nr_lbas <= geometry.lba_count);
 
 	// Get pointer to the start of the requested memory location
@@ -21,7 +21,7 @@ idx_t FakeDevice::Write(void *buffer, CmdContext context) {
 	return context.nr_lbas;
 }
 
-idx_t FakeDevice::Read(void *buffer, CmdContext context) {
+idx_t FakeDevice::Read(void *buffer, const CmdContext &context) {
 	D_ASSERT(context.start_lba + context.nr_lbas <= geometry.lba_count);
 
 	// Get pointer to the start of the requested memory location

--- a/src/include/fake_device.hpp
+++ b/src/include/fake_device.hpp
@@ -8,8 +8,8 @@ public:
 	FakeDevice(idx_t lba_count, idx_t lba_size = DEFAULT_BLOCK_SIZE);
 	~FakeDevice();
 
-	idx_t Write(void *buffer, CmdContext context) override;
-	idx_t Read(void *buffer, CmdContext context) override;
+	idx_t Write(void *buffer, const CmdContext &context) override;
+	idx_t Read(void *buffer, const CmdContext &context) override;
 
 	DeviceGeometry GetDeviceGeometry() override;
 

--- a/src/include/fake_device.hpp
+++ b/src/include/fake_device.hpp
@@ -19,5 +19,6 @@ public:
 
 private:
 	const DeviceGeometry geometry;
+	vector<uint8_t> memory;
 };
 } // namespace duckdb

--- a/src/include/fake_device.hpp
+++ b/src/include/fake_device.hpp
@@ -1,0 +1,23 @@
+#include "nvme_device.hpp"
+
+namespace duckdb {
+constexpr idx_t DEFAULT_BLOCK_SIZE = 1ULL << 12;
+
+class FakeDevice : public Device {
+public:
+	FakeDevice(idx_t lba_count, idx_t lba_size = DEFAULT_BLOCK_SIZE);
+	~FakeDevice();
+
+	idx_t Write(void *buffer, CmdContext context) override;
+	idx_t Read(void *buffer, CmdContext context) override;
+
+	DeviceGeometry GetDeviceGeometry() override;
+
+	string GetName() const override {
+		return "FakeDevice";
+	}
+
+private:
+	const DeviceGeometry geometry;
+};
+} // namespace duckdb


### PR DESCRIPTION
This fake device is an in-memory replica of the device. It does not do any NVMe specific funtionality other than reading and writing data to memory.
`FakeDevice` is intended to be used testing purposes only! This is a nice addition to our refactoring setup which allows us to test that the internal implementation of our `NvmeFileSystem` actually works and places data correctly.

