### PR TITLE
Add automatic use of ninja when using `make` functions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,4 +6,6 @@ RUN bash -e ./toolbox/pkgs/ubuntu-jammy.sh
 
 RUN rm -rf /usr/local/vcpkg
 
+ENV GEN=ninja
+
 CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ run:
 dealloc-device:
 	@sh ./scripts/dealloc_device.sh
 
-gtest:
-	GEN=ninja make release
+gtest: release
 	@./build/release/gtests/nvmefs_gtest
 
 clean-gtest: clean gtest


### PR DESCRIPTION
- **Remove GEN=ninja when building tests**
- **Add gen ninja as a environment variable in the dockerfile**
