### PR TITLE
Implement an LBA block allocator for temporary storage for `nvmefs`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(src/include)
 
 set(EXTENSION_SOURCES 
   src/nvmefs_extension.cpp
+  src/nvmefs_temporary_block_manager.cpp
   src/nvmefs.cpp
   src/nvmefs_config.cpp
   src/device.cpp

--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -14,6 +14,7 @@ namespace duckdb {
 constexpr idx_t NVMEFS_GLOBAL_METADATA_LOCATION = 0;
 constexpr char NVMEFS_MAGIC_BYTES[] = "NVMEFS";
 const string NVMEFS_PATH_PREFIX = "nvmefs://";
+const string NVMEFS_TMP_DIR_PATH = "nvmefs:///tmp";
 const string NVMEFS_GLOBAL_METADATA_PATH = "nvmefs://.global_metadata";
 
 enum MetadataType { DATABASE, WAL, TEMPORARY };
@@ -93,7 +94,12 @@ public:
 	void CreateDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr) override;
 	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
 	void Seek(FileHandle &handle, idx_t location) override;
+	void Reset(FileHandle &handle);
 	idx_t SeekPosition(FileHandle &handle) override;
+	bool ListFiles(const string &directory,
+		const std::function<void(const string &, bool)> &callback,
+		FileOpener *opener = nullptr);
+	optional_idx GetAvailableDiskSpace(const string &path);
 	bool Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) override;
 
 	Device &GetDevice();

--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -108,7 +108,7 @@ private:
 	void WriteMetadata(GlobalMetadata &global);
 	void UpdateMetadata(CmdContext &Context);
 	MetadataType GetMetadataType(const string &filename);
-	idx_t GetLBA(const string &filename, idx_t nr_bytes, idx_t location);
+	idx_t GetLBA(const string &filename, idx_t nr_bytes, idx_t location, idx_t nr_lbas);
 
 	/// @brief Checks that the start_lba is within the assigned metadata range and that lba_start+lba_count is within
 	/// the assigned metadata range

--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -109,9 +109,6 @@ private:
 	void UpdateMetadata(CmdContext &Context);
 	MetadataType GetMetadataType(const string &filename);
 	idx_t GetLBA(const string &filename, idx_t nr_bytes, idx_t location);
-	idx_t GetStartLBA(const string &filename);
-	idx_t GetLocationLBA(const string &filename);
-	idx_t GetEndLBA(const string &filename);
 
 	/// @brief Checks that the start_lba is within the assigned metadata range and that lba_start+lba_count is within
 	/// the assigned metadata range

--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -94,6 +94,7 @@ public:
 	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
 	void Seek(FileHandle &handle, idx_t location) override;
 	idx_t SeekPosition(FileHandle &handle) override;
+	bool Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) override;
 
 	Device &GetDevice();
 

--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -127,5 +127,6 @@ private:
 	map<string, TemporaryFileMetadata> file_to_temp_meta;
 	idx_t max_temp_size;
 	idx_t max_wal_size;
+	static std::recursive_mutex api_lock;
 };
 } // namespace duckdb

--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -7,6 +7,7 @@
 #include "device.hpp"
 #include "nvme_device.hpp"
 #include "nvmefs_config.hpp"
+#include "nvmefs_temporary_block_manager.hpp"
 
 namespace duckdb {
 
@@ -33,8 +34,8 @@ struct GlobalMetadata {
 };
 
 struct TemporaryFileMetadata {
-	uint64_t start;
-	uint64_t end;
+	uint64_t block_size;
+	map<idx_t, TemporaryBlock *> block_map;
 };
 
 class NvmeFileHandle : public FileHandle {
@@ -107,7 +108,7 @@ private:
 	void WriteMetadata(GlobalMetadata &global);
 	void UpdateMetadata(CmdContext &Context);
 	MetadataType GetMetadataType(const string &filename);
-	idx_t GetLBA(const string &filename, idx_t location);
+	idx_t GetLBA(const string &filename, idx_t nr_bytes, idx_t location);
 	idx_t GetStartLBA(const string &filename);
 	idx_t GetLocationLBA(const string &filename);
 	idx_t GetEndLBA(const string &filename);
@@ -125,6 +126,7 @@ private:
 	unique_ptr<GlobalMetadata> metadata;
 	unique_ptr<Device> device;
 	map<string, TemporaryFileMetadata> file_to_temp_meta;
+	NvmeTemporaryBlockManager temp_block_manager;
 	idx_t max_temp_size;
 	idx_t max_wal_size;
 	static std::recursive_mutex api_lock;

--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -126,7 +126,7 @@ private:
 	unique_ptr<GlobalMetadata> metadata;
 	unique_ptr<Device> device;
 	map<string, TemporaryFileMetadata> file_to_temp_meta;
-	NvmeTemporaryBlockManager temp_block_manager;
+	unique_ptr<NvmeTemporaryBlockManager> temp_block_manager;
 	idx_t max_temp_size;
 	idx_t max_wal_size;
 	static std::recursive_mutex api_lock;

--- a/src/include/nvmefs_temporary_block_manager.hpp
+++ b/src/include/nvmefs_temporary_block_manager.hpp
@@ -53,6 +53,7 @@ private:
 	/// @return The splitted block
 	TemporaryBlock *SplitBlock(TemporaryBlock *block, idx_t lba_amount);
 	void PrintBlocks(TemporaryBlock *block);
+	void PrintBlocksBackwards(TemporaryBlock *block);
 
 	/// @brief Looks if the previous and next blocks are free. If they are, it merges them into one block.
 	/// @param block The block to merge

--- a/src/include/nvmefs_temporary_block_manager.hpp
+++ b/src/include/nvmefs_temporary_block_manager.hpp
@@ -28,11 +28,11 @@ private:
 
 	// The next and previous blocks in the linked list
 	unique_ptr<TemporaryBlock> next_block;
-	unique_ptr<TemporaryBlock> previous_block;
+	TemporaryBlock *previous_block;
 
 	// The next and previous blocks of the same size
-	unique_ptr<TemporaryBlock> next_size_block;
-	unique_ptr<TemporaryBlock> previous_size_block;
+	TemporaryBlock *next_free_block;
+	TemporaryBlock *previous_free_block;
 };
 
 class NvmeTemporaryBlockManager {

--- a/src/include/nvmefs_temporary_block_manager.hpp
+++ b/src/include/nvmefs_temporary_block_manager.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "nvmefs.hpp"
-#include "nvmefs_config.hpp"
 
 namespace duckdb {
 

--- a/src/include/nvmefs_temporary_block_manager.hpp
+++ b/src/include/nvmefs_temporary_block_manager.hpp
@@ -40,8 +40,8 @@ public:
 	NvmeTemporaryBlockManager(idx_t allocated_lba_start, idx_t allocated_lba_end);
 
 public:
-	TemporaryBlock &AllocateBlock(idx_t lba_amount);
-	void FreeBlock(TemporaryBlock &block);
+	TemporaryBlock *AllocateBlock(idx_t lba_amount);
+	void FreeBlock(TemporaryBlock *block);
 
 private:
 	uint8_t GetFreeListIndex(idx_t lba_amount);
@@ -55,7 +55,7 @@ private:
 
 	/// @brief Looks if the previous and next blocks are free. If they are, it merges them into one block.
 	/// @param block The block to merge
-	void CoalesceFreeBlocks(TemporaryBlock &block);
+	void CoalesceFreeBlocks(TemporaryBlock *block);
 
 	void PushFreeBlock(TemporaryBlock *block);
 	TemporaryBlock *PopFreeBlock(uint8_t free_list_index);

--- a/src/include/nvmefs_temporary_block_manager.hpp
+++ b/src/include/nvmefs_temporary_block_manager.hpp
@@ -52,16 +52,21 @@ private:
 	/// @param block The block to split
 	/// @param lba_amount Amount that the new splitted block should have
 	/// @return The splitted block
-	TemporaryBlock &SplitBlock(TemporaryBlock &block, idx_t lba_amount);
+	TemporaryBlock *SplitBlock(TemporaryBlock *block, idx_t lba_amount);
 
 	/// @brief Looks if the previous and next blocks are free. If they are, it merges them into one block.
 	/// @param block The block to merge
 	void CoalesceFreeBlocks(TemporaryBlock &block);
 
+	void PushFreeBlock(TemporaryBlock *block);
+	TemporaryBlock *PopFreeBlock(uint8_t free_list_index);
+	void RemoveFreeBlock(TemporaryBlock *block);
+
 private:
 	/// @brief Free blocks are stored in a vector of unique_ptrs to TemporaryBlock objects. This is to sort a block into
 	/// a linked list of equally sized blocks so that it is quicker to fetch the block that is needed.
-	vector<unique_ptr<TemporaryBlock>> blocks;
+	unique_ptr<TemporaryBlock> blocks;
+	vector<TemporaryBlock *> blocks_free;
 };
 
 } // namespace duckdb

--- a/src/include/nvmefs_temporary_block_manager.hpp
+++ b/src/include/nvmefs_temporary_block_manager.hpp
@@ -38,7 +38,6 @@ private:
 class NvmeTemporaryBlockManager {
 public:
 	NvmeTemporaryBlockManager(idx_t allocated_lba_start, idx_t allocated_lba_end);
-	~NvmeTemporaryBlockManager();
 
 public:
 	TemporaryBlock &AllocateBlock(idx_t lba_amount);

--- a/src/include/nvmefs_temporary_block_manager.hpp
+++ b/src/include/nvmefs_temporary_block_manager.hpp
@@ -52,6 +52,7 @@ private:
 	/// @param lba_amount Amount that the new splitted block should have
 	/// @return The splitted block
 	TemporaryBlock *SplitBlock(TemporaryBlock *block, idx_t lba_amount);
+	void PrintBlocks(TemporaryBlock *block);
 
 	/// @brief Looks if the previous and next blocks are free. If they are, it merges them into one block.
 	/// @param block The block to merge
@@ -66,6 +67,9 @@ private:
 	/// a linked list of equally sized blocks so that it is quicker to fetch the block that is needed.
 	unique_ptr<TemporaryBlock> blocks;
 	vector<TemporaryBlock *> blocks_free;
+
+	idx_t allocated_start_lba;
+	idx_t allocated_end_lba;
 };
 
 } // namespace duckdb

--- a/src/include/nvmefs_temporary_block_manager.hpp
+++ b/src/include/nvmefs_temporary_block_manager.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include "nvmefs.hpp"
+#include "nvmefs_config.hpp"
+
+namespace duckdb {
+
+/// @brief TemporaryBlock is a class that represents a block of LBAs that are use to store temporary data.
+class TemporaryBlock {
+	friend class NvmeTemporaryBlockManager;
+
+public:
+	/// @brief Constructor for TemporaryBlock
+	/// @param start_lba Start LBA of the block (inclusive)
+	/// @param lba_amount Number of LBAs in the block
+	TemporaryBlock(idx_t start_lba, idx_t lba_amount);
+	idx_t GetSizeInBytes();
+	idx_t GetStartLBA();
+	idx_t GetEndLBA();
+
+	bool IsFree();
+
+private:
+	idx_t start_lba;
+	idx_t lba_amount;
+	bool is_free;
+
+	// The next and previous blocks in the linked list
+	unique_ptr<TemporaryBlock> next_block;
+	unique_ptr<TemporaryBlock> previous_block;
+
+	// The next and previous blocks of the same size
+	unique_ptr<TemporaryBlock> next_size_block;
+	unique_ptr<TemporaryBlock> previous_size_block;
+};
+
+class NvmeTemporaryBlockManager {
+public:
+	NvmeTemporaryBlockManager(idx_t allocated_lba_start, idx_t allocated_lba_end);
+	~NvmeTemporaryBlockManager();
+
+public:
+	TemporaryBlock &AllocateBlock(idx_t lba_amount);
+	void FreeBlock(TemporaryBlock &block);
+
+private:
+	uint8_t GetFreeListIndex(idx_t lba_amount);
+
+	/// @brief Splits a block into two blocks. The first block will be the requested size and the second block will be
+	/// the remaining size.
+	/// @param block The block to split
+	/// @param lba_amount Amount that the new splitted block should have
+	/// @return The splitted block
+	TemporaryBlock &SplitBlock(TemporaryBlock &block, idx_t lba_amount);
+
+	/// @brief Looks if the previous and next blocks are free. If they are, it merges them into one block.
+	/// @param block The block to merge
+	void CoalesceFreeBlocks(TemporaryBlock &block);
+
+private:
+	/// @brief Free blocks are stored in a vector of unique_ptrs to TemporaryBlock objects. This is to sort a block into
+	/// a linked list of equally sized blocks so that it is quicker to fetch the block that is needed.
+	vector<unique_ptr<TemporaryBlock>> blocks;
+};
+
+} // namespace duckdb

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -270,12 +270,13 @@ void NvmeFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 			idx_t to_block_index = new_size / tfmeta.block_size;
 			idx_t from_block_index = tfmeta.block_map.size();
 
-			for (idx_t i = from_block_index - 1; i > to_block_index; i--) {
-				TemporaryBlock *block = tfmeta.block_map[i];
+			for (idx_t i = from_block_index; i > to_block_index; i--) {
+				idx_t block_index = i - 1;
+				TemporaryBlock *block = tfmeta.block_map[block_index];
 				temp_block_manager->FreeBlock(block);
 
 				printf("Blockmap size before: %zu\n", tfmeta.block_map.size());
-				tfmeta.block_map.erase(i);
+				tfmeta.block_map.erase(block_index);
 				printf("Blockmap size after: %zu\n", tfmeta.block_map.size());
 			}
 			file_to_temp_meta[nvme_handle.path] = tfmeta;

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -274,7 +274,9 @@ void NvmeFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 				TemporaryBlock *block = tfmeta.block_map[i];
 				temp_block_manager->FreeBlock(block);
 
+				printf("Blockmap size before: %zu\n", tfmeta.block_map.size());
 				tfmeta.block_map.erase(i);
+				printf("Blockmap size after: %zu\n", tfmeta.block_map.size());
 			}
 			file_to_temp_meta[nvme_handle.path] = tfmeta;
 		} break;

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -279,6 +279,7 @@ void NvmeFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 				printf("Blockmap size after: %zu\n", tfmeta.block_map.size());
 			}
 			file_to_temp_meta[nvme_handle.path] = tfmeta;
+			printf("Blockmap size after truncation: %zu\n", file_to_temp_meta[nvme_handle.path].block_map.size());
 		} break;
 		default:
 			throw InvalidInputException("Unknown metadata type");

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -270,7 +270,7 @@ void NvmeFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 			idx_t to_block_index = new_size / tfmeta.block_size;
 			idx_t from_block_index = tfmeta.block_map.size();
 
-			for (idx_t i = from_block_index; i > from_block_index; i--) {
+			for (idx_t i = from_block_index; i > to_block_index; i--) {
 				TemporaryBlock *block = tfmeta.block_map[i];
 				temp_block_manager->FreeBlock(block);
 

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -184,8 +184,8 @@ bool NvmeFileSystem::FileExists(const string &filename, optional_ptr<FileOpener>
 		break;
 	case DATABASE:
 		if (StringUtil::Equals(path_no_ext.data(), db_path_no_ext.data())) {
-			uint64_t start_lba = GetStartLBA(filename);
-			uint64_t location_lba = GetLocationLBA(filename);
+			uint64_t start_lba = metadata->database.start;
+			uint64_t location_lba = metadata->database.location;
 
 			if ((location_lba - start_lba) > 0) {
 				exists = true;

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -137,12 +137,16 @@ void NvmeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, i
 }
 
 int64_t NvmeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	api_lock.lock();
 	Read(handle, buffer, nr_bytes, 0);
+	api_lock.unlock();
 	return nr_bytes;
 }
 
 int64_t NvmeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	api_lock.lock();
 	Write(handle, buffer, nr_bytes, 0);
+	api_lock.unlock();
 	return nr_bytes;
 }
 

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -63,6 +63,8 @@ idx_t NvmeFileHandle::GetFilePointer() {
 
 ////////////////////////////////////////
 
+std::recursive_mutex NvmeFileSystem::api_lock;
+
 NvmeFileSystem::NvmeFileSystem(NvmeConfig config)
     : allocator(Allocator::DefaultAllocator()), device(make_uniq<NvmeDevice>(config.device_path, config.plhdls, config.backend, config.async)),
       max_temp_size(config.max_temp_size), max_wal_size(config.max_wal_size) {
@@ -75,6 +77,7 @@ NvmeFileSystem::NvmeFileSystem(NvmeConfig config, unique_ptr<Device> device)
 
 unique_ptr<FileHandle> NvmeFileSystem::OpenFile(const string &path, FileOpenFlags flags,
                                                 optional_ptr<FileOpener> opener) {
+	api_lock.lock();
 	bool internal = StringUtil::Equals(NVMEFS_GLOBAL_METADATA_PATH.data(), path.data());
 	if (!internal && !TryLoadMetadata()) {
 		if (GetMetadataType(path) != MetadataType::DATABASE) {
@@ -84,11 +87,12 @@ unique_ptr<FileHandle> NvmeFileSystem::OpenFile(const string &path, FileOpenFlag
 		}
 	}
 	unique_ptr<FileHandle> handle = make_uniq<NvmeFileHandle>(*this, path, flags);
+	api_lock.unlock();
 	return std::move(handle);
 }
 
 void NvmeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
-
+	api_lock.lock();
 	NvmeFileHandle &fh = handle.Cast<NvmeFileHandle>();
 	DeviceGeometry geo = device->GetDeviceGeometry();
 
@@ -103,9 +107,11 @@ void NvmeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 	}
 
 	device->Read(buffer, *cmd_ctx);
+	api_lock.unlock();
 }
 
 void NvmeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	api_lock.lock();
 	NvmeFileHandle &fh = handle.Cast<NvmeFileHandle>();
 	DeviceGeometry geo = device->GetDeviceGeometry();
 
@@ -121,6 +127,7 @@ void NvmeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, i
 
 	idx_t written_lbas = device->Write(buffer, *cmd_ctx);
 	UpdateMetadata(*cmd_ctx);
+	api_lock.unlock();
 }
 
 int64_t NvmeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
@@ -138,6 +145,7 @@ bool NvmeFileSystem::CanHandleFile(const string &fpath) {
 }
 
 bool NvmeFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
+	api_lock.lock();
 	if (!TryLoadMetadata()) {
 		return false;
 	}
@@ -183,18 +191,19 @@ bool NvmeFileSystem::FileExists(const string &filename, optional_ptr<FileOpener>
 		throw IOException("No such metadata type");
 		break;
 	}
-
+	api_lock.unlock();
 	return exists;
 }
 
 int64_t NvmeFileSystem::GetFileSize(FileHandle &handle) {
+	api_lock.lock();
 	DeviceGeometry geo = device->GetDeviceGeometry();
 	NvmeFileHandle &fh = handle.Cast<NvmeFileHandle>();
 	MetadataType type = GetMetadataType(fh.path);
 
 	idx_t start_lba = GetStartLBA(fh.path);
 	idx_t location_lba = GetLocationLBA(fh.path);
-
+	api_lock.unlock();
 	return (location_lba - start_lba) * geo.lba_size;
 }
 
@@ -208,6 +217,7 @@ bool NvmeFileSystem::OnDiskFile(FileHandle &handle) {
 }
 
 void NvmeFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
+	api_lock.lock();
 	NvmeFileHandle &nvme_handle = handle.Cast<NvmeFileHandle>();
 	int64_t current_size = GetFileSize(nvme_handle);
 
@@ -234,18 +244,22 @@ void NvmeFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 	} else {
 		throw InvalidInputException("new_size is bigger than the current file size.");
 	}
+	api_lock.unlock();
 }
 
 bool NvmeFileSystem::DirectoryExists(const string &directory, optional_ptr<FileOpener> opener) {
+	api_lock.lock();
 	// The directory exists if metadata exists
 	if (TryLoadMetadata()) {
+		api_lock.unlock();
 		return true;
 	}
-
+	api_lock.unlock();
 	return false;
 }
 
 void NvmeFileSystem::RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener) {
+	api_lock.lock();
 	// We only support removal of temporary directory
 	MetadataType type = GetMetadataType(directory);
 	if (type == MetadataType::TEMPORARY) {
@@ -253,17 +267,21 @@ void NvmeFileSystem::RemoveDirectory(const string &directory, optional_ptr<FileO
 	} else {
 		throw IOException("Cannot delete unknown directory");
 	}
+	api_lock.unlock();
 }
 
 void NvmeFileSystem::CreateDirectory(const string &directory, optional_ptr<FileOpener> opener) {
 	// All necessary directories (i.e. tmp and main folder) is already created
 	// if metadata is present
+	api_lock.lock();
 	if (!TryLoadMetadata()) {
 		throw IOException("No directories can exist when there is no metadata");
 	}
+	api_lock.unlock();
 }
 
 void NvmeFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
+	api_lock.lock();
 	MetadataType type = GetMetadataType(filename);
 
 	switch (type) {
@@ -281,9 +299,11 @@ void NvmeFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener>
 		// No other files to delete - we only have the database file, temporary files and the write_ahead_log
 		break;
 	}
+	api_lock.unlock();
 }
 
 void NvmeFileSystem::Seek(FileHandle &handle, idx_t location) {
+	api_lock.lock();
 	NvmeFileHandle &nvme_handle = handle.Cast<NvmeFileHandle>();
 	DeviceGeometry geo = device->GetDeviceGeometry();
 	// We only support seek to start of an LBA block
@@ -298,10 +318,13 @@ void NvmeFileSystem::Seek(FileHandle &handle, idx_t location) {
 	}
 
 	nvme_handle.SetFilePointer(location);
+	api_lock.unlock();
 }
 
 idx_t NvmeFileSystem::SeekPosition(FileHandle &handle) {
+	api_lock.lock();
 	return handle.Cast<NvmeFileHandle>().GetFilePointer();
+	api_lock.unlock();
 }
 Device &NvmeFileSystem::GetDevice() {
 	return *device;

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -270,7 +270,7 @@ void NvmeFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 			idx_t to_block_index = new_size / tfmeta.block_size;
 			idx_t from_block_index = tfmeta.block_map.size();
 
-			for (idx_t i = from_block_index; i > to_block_index; i--) {
+			for (idx_t i = from_block_index - 1; i > to_block_index; i--) {
 				TemporaryBlock *block = tfmeta.block_map[i];
 				temp_block_manager->FreeBlock(block);
 

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -401,6 +401,16 @@ Device &NvmeFileSystem::GetDevice() {
 	return *device;
 }
 
+bool NvmeFileSystem::Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) {
+	data_ptr_t data = allocator.AllocateData(length_bytes);
+
+	memset(data, 0, length_bytes);
+	Write(handle, data, length_bytes, offset_bytes);
+
+	allocator.FreeData(data, length_bytes);
+	return true;
+}
+
 bool NvmeFileSystem::TryLoadMetadata() {
 	if (metadata) {
 		return true;

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -345,12 +345,9 @@ void NvmeFileSystem::Seek(FileHandle &handle, idx_t location) {
 }
 
 idx_t NvmeFileSystem::SeekPosition(FileHandle &handle) {
-	api_lock.lock();
-	std::cout << "Locking SeekPosition\n";
 	return handle.Cast<NvmeFileHandle>().GetFilePointer();
-	std::cout << "Unlocking SeekPoisition\n";
-	api_lock.unlock();
 }
+
 Device &NvmeFileSystem::GetDevice() {
 	return *device;
 }

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -264,13 +264,10 @@ void NvmeFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 				idx_t block_index = i - 1;
 				TemporaryBlock *block = tfmeta.block_map[block_index];
 				temp_block_manager->FreeBlock(block);
-
-				printf("Blockmap size before: %zu\n", tfmeta.block_map.size());
 				tfmeta.block_map.erase(block_index);
-				printf("Blockmap size after: %zu\n", tfmeta.block_map.size());
 			}
+
 			file_to_temp_meta[nvme_handle.path] = tfmeta;
-			printf("Blockmap size after truncation: %zu\n", file_to_temp_meta[nvme_handle.path].block_map.size());
 		} break;
 		default:
 			throw InvalidInputException("Unknown metadata type");

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -560,6 +560,7 @@ idx_t NvmeFileSystem::GetLBA(const string &filename, idx_t nr_bytes, idx_t locat
 				tfmeta.block_map[block_index] = block;
 			}
 			lba = tfmeta.block_map[block_index]->GetStartLBA();
+			file_to_temp_meta[filename] = tfmeta;
 
 		} else {
 			tfmeta = {.block_size = nr_lbas * geo.lba_size};
@@ -568,7 +569,6 @@ idx_t NvmeFileSystem::GetLBA(const string &filename, idx_t nr_bytes, idx_t locat
 			idx_t block_index = location / tfmeta.block_size;
 
 			TemporaryBlock *block = temp_block_manager->AllocateBlock(nr_lbas);
-			printf("Allocating block %d with size %d\n", block->GetStartLBA(), block->GetSizeInBytes());
 			file_to_temp_meta[filename].block_map[block_index] = block;
 			lba = block->GetStartLBA();
 		}

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -79,7 +79,6 @@ NvmeFileSystem::NvmeFileSystem(NvmeConfig config, unique_ptr<Device> device)
 unique_ptr<FileHandle> NvmeFileSystem::OpenFile(const string &path, FileOpenFlags flags,
                                                 optional_ptr<FileOpener> opener) {
 	api_lock.lock();
-	// std::cout << "Locking Openfile\n";
 	bool internal = StringUtil::Equals(NVMEFS_GLOBAL_METADATA_PATH.data(), path.data());
 	if (!internal && !TryLoadMetadata()) {
 		if (GetMetadataType(path) != MetadataType::DATABASE) {
@@ -89,14 +88,12 @@ unique_ptr<FileHandle> NvmeFileSystem::OpenFile(const string &path, FileOpenFlag
 		}
 	}
 	unique_ptr<FileHandle> handle = make_uniq<NvmeFileHandle>(*this, path, flags);
-	// std::cout << "Unlocking Openfile\n";
 	api_lock.unlock();
 	return std::move(handle);
 }
 
 void NvmeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	api_lock.lock();
-	// std::cout << "Locking Read\n";
 	NvmeFileHandle &fh = handle.Cast<NvmeFileHandle>();
 	DeviceGeometry geo = device->GetDeviceGeometry();
 
@@ -112,13 +109,11 @@ void NvmeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 	}
 
 	device->Read(buffer, *cmd_ctx);
-	// std::cout << "Unocking Read\n";
 	api_lock.unlock();
 }
 
 void NvmeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	api_lock.lock();
-	// std::cout << "Locking Write\n";
 	NvmeFileHandle &fh = handle.Cast<NvmeFileHandle>();
 	DeviceGeometry geo = device->GetDeviceGeometry();
 
@@ -135,7 +130,6 @@ void NvmeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, i
 
 	idx_t written_lbas = device->Write(buffer, *cmd_ctx);
 	UpdateMetadata(*cmd_ctx);
-	// std::cout << "Unlocking Write\n";
 	api_lock.unlock();
 }
 
@@ -159,7 +153,6 @@ bool NvmeFileSystem::CanHandleFile(const string &fpath) {
 
 bool NvmeFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
 	api_lock.lock();
-	// std::cout << "Locking FileExists\n";
 	if (!TryLoadMetadata()) {
 		return false;
 	}
@@ -205,14 +198,12 @@ bool NvmeFileSystem::FileExists(const string &filename, optional_ptr<FileOpener>
 		throw IOException("No such metadata type");
 		break;
 	}
-	// std::cout << "Unlocking FileExists\n";
 	api_lock.unlock();
 	return exists;
 }
 
 int64_t NvmeFileSystem::GetFileSize(FileHandle &handle) {
 	api_lock.lock();
-	// std::cout << "Locking GetFileSize\n";
 	DeviceGeometry geo = device->GetDeviceGeometry();
 	NvmeFileHandle &fh = handle.Cast<NvmeFileHandle>();
 	MetadataType type = GetMetadataType(fh.path);
@@ -249,7 +240,6 @@ bool NvmeFileSystem::OnDiskFile(FileHandle &handle) {
 
 void NvmeFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 	api_lock.lock();
-	// std::cout << "Locking Truncate\n";
 	NvmeFileHandle &nvme_handle = handle.Cast<NvmeFileHandle>();
 	int64_t current_size = GetFileSize(nvme_handle);
 
@@ -289,27 +279,22 @@ void NvmeFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 	} else {
 		throw InvalidInputException("new_size is bigger than the current file size.");
 	}
-	// std::cout << "Unlocking Truncate\n";
 	api_lock.unlock();
 }
 
 bool NvmeFileSystem::DirectoryExists(const string &directory, optional_ptr<FileOpener> opener) {
 	api_lock.lock();
-	// std::cout << "Locking DirectoryExists\n";
 	// The directory exists if metadata exists
 	if (TryLoadMetadata()) {
 		api_lock.unlock();
-		// std::cout << "Unlocking DirectoryExists\n";
 		return true;
 	}
 	api_lock.unlock();
-	// std::cout << "Unlocking DirectoryExists\n";
 	return false;
 }
 
 void NvmeFileSystem::RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener) {
 	api_lock.lock();
-	// std::cout << "Locking RemoveDirectory\n";
 	// We only support removal of temporary directory
 	MetadataType type = GetMetadataType(directory);
 	if (type == MetadataType::TEMPORARY) {
@@ -317,7 +302,6 @@ void NvmeFileSystem::RemoveDirectory(const string &directory, optional_ptr<FileO
 	} else {
 		throw IOException("Cannot delete unknown directory");
 	}
-	// std::cout << "Unlocking RemoveDirectory\n";
 	api_lock.unlock();
 }
 
@@ -325,11 +309,9 @@ void NvmeFileSystem::CreateDirectory(const string &directory, optional_ptr<FileO
 	// All necessary directories (i.e. tmp and main folder) is already created
 	// if metadata is present
 	api_lock.lock();
-	// std::cout << "Locking CreateDirectory\n";
 	if (!TryLoadMetadata()) {
 		throw IOException("No directories can exist when there is no metadata");
 	}
-	// std::cout << "Unlocking CreateDirectory\n";
 	api_lock.unlock();
 }
 
@@ -359,7 +341,6 @@ void NvmeFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener>
 
 void NvmeFileSystem::Seek(FileHandle &handle, idx_t location) {
 	api_lock.lock();
-	// std::cout << "Locking Seek\n";
 	NvmeFileHandle &nvme_handle = handle.Cast<NvmeFileHandle>();
 	DeviceGeometry geo = device->GetDeviceGeometry();
 	// We only support seek to start of an LBA block
@@ -389,7 +370,6 @@ void NvmeFileSystem::Seek(FileHandle &handle, idx_t location) {
 	}
 
 	nvme_handle.SetFilePointer(location);
-	// std::cout << "Unlocking Seek\n";
 	api_lock.unlock();
 }
 

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -276,6 +276,7 @@ void NvmeFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 
 				tfmeta.block_map.erase(i);
 			}
+			file_to_temp_meta[nvme_handle.path] = tfmeta;
 		} break;
 		default:
 			throw InvalidInputException("Unknown metadata type");

--- a/src/nvmefs_temporary_block_manager.cpp
+++ b/src/nvmefs_temporary_block_manager.cpp
@@ -12,7 +12,7 @@ TemporaryBlock::TemporaryBlock(idx_t start_lba, idx_t lba_amount)
 }
 
 idx_t TemporaryBlock::GetSizeInBytes() {
-	return (lba_amount + 1) * 4096; // TODO: Get the LBA size from the device
+	return lba_amount * 4096; // TODO: Get the LBA size from the device
 }
 
 idx_t TemporaryBlock::GetStartLBA() {
@@ -20,7 +20,7 @@ idx_t TemporaryBlock::GetStartLBA() {
 }
 
 idx_t TemporaryBlock::GetEndLBA() {
-	return start_lba + lba_amount;
+	return start_lba + lba_amount - 1;
 }
 
 bool TemporaryBlock::IsFree() {
@@ -91,7 +91,7 @@ TemporaryBlock *NvmeTemporaryBlockManager::AllocateBlock(idx_t lba_amount) {
 
 TemporaryBlock *NvmeTemporaryBlockManager::SplitBlock(TemporaryBlock *block, idx_t lba_amount) {
 	// Create a new block with the remaining size
-	unique_ptr<TemporaryBlock> new_block = make_uniq<TemporaryBlock>(block->start_lba, lba_amount - 1);
+	unique_ptr<TemporaryBlock> new_block = make_uniq<TemporaryBlock>(block->start_lba, lba_amount);
 	TemporaryBlock *new_block_ptr = new_block.get();
 
 	// Update the original block size

--- a/src/nvmefs_temporary_block_manager.cpp
+++ b/src/nvmefs_temporary_block_manager.cpp
@@ -1,0 +1,85 @@
+#include "nvmefs_temporary_block_manager.hpp"
+#include <optional>
+
+namespace duckdb {
+TemporaryBlock::TemporaryBlock(idx_t start_lba, idx_t lba_amount)
+    : start_lba(start_lba), lba_amount(lba_amount), is_free(true) {
+}
+
+idx_t TemporaryBlock::GetSizeInBytes() {
+	return lba_amount * 4096; // TODO: Get the LBA size from the device
+}
+
+idx_t TemporaryBlock::GetStartLBA() {
+	return start_lba;
+}
+
+idx_t TemporaryBlock::GetEndLBA() {
+	return start_lba + lba_amount;
+}
+
+bool TemporaryBlock::IsFree() {
+	return is_free;
+}
+
+NvmeTemporaryBlockManager::NvmeTemporaryBlockManager(idx_t allocated_lba_start, idx_t allocated_lba_end) {
+	// Initialize the linked list of free blocks
+	blocks =
+	    vector<unique_ptr<TemporaryBlock>>(8); // There are 8 different allocation sizes for the TemporaryBufferSize
+	blocks[7] = make_unique<TemporaryBlock>(allocated_lba_start, allocated_lba_end - allocated_lba_start);
+}
+
+uint8_t NvmeTemporaryBlockManager::GetFreeListIndex(idx_t lba_amount) {
+	// Get the index of the free list for the given size
+	if (lba_amount <= 8) {
+		return 0;
+	} else if (lba_amount <= 16) {
+		return 1;
+	} else if (lba_amount <= 24) {
+		return 2;
+	} else if (lba_amount <= 32) {
+		return 3;
+	} else if (lba_amount <= 40) {
+		return 4;
+	} else if (lba_amount <= 48) {
+		return 5;
+	} else if (lba_amount <= 56) {
+		return 6;
+	} else if (lba_amount <= 64) {
+		return 7;
+	}
+
+	return 7;
+}
+
+TemporaryBlock &NvmeTemporaryBlockManager::AllocateBlock(idx_t lba_amount) {
+	// Get the free list index for the given size
+	uint8_t free_list_index = GetFreeListIndex(lba_amount);
+
+	// Get the free block from the free list
+	for (uint8_t i = free_list_index; i < 8; i++) {
+		if (blocks[i] != nullptr) {
+			// Get the block from the free list
+			TemporaryBlock &block = *blocks[i];
+
+			// Check if the block is large enough
+			// Split the block if it is larger than the requested size
+			if (block.lba_amount > lba_amount) {
+				block = SplitBlock(block, lba_amount);
+			}
+
+			// Mark the block as used
+			block.is_free = false;
+
+			return block;
+		}
+	}
+
+	// Mark the block as used
+	block.is_free = false;
+
+	// Return the block
+	return block;
+}
+
+} // namespace duckdb

--- a/src/nvmefs_temporary_block_manager.cpp
+++ b/src/nvmefs_temporary_block_manager.cpp
@@ -4,6 +4,11 @@
 namespace duckdb {
 TemporaryBlock::TemporaryBlock(idx_t start_lba, idx_t lba_amount)
     : start_lba(start_lba), lba_amount(lba_amount), is_free(true) {
+
+	next_block = nullptr;
+	previous_block = nullptr;
+	next_free_block = nullptr;
+	previous_free_block = nullptr;
 }
 
 idx_t TemporaryBlock::GetSizeInBytes() {

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -26,7 +26,7 @@ include_directories(${CMAKE_SOURCE_DIR}/duckdb/src/include)
 
 add_executable(nvmefs_gtest "test_nvmefs_proxy.cpp")
 
-target_link_libraries(nvmefs_gtest GTest::gtest_main ${EXTENSION_NAME} duckdb gtest_utils)
+target_link_libraries(nvmefs_gtest GTest::gtest_main ${EXTENSION_NAME} duckdb gtest_utils gmock)
 set_target_properties(nvmefs_gtest PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/gtests")
 target_compile_options(nvmefs_gtest PRIVATE -fexceptions)
 

--- a/test/gtest/test_nvmefs_proxy.cpp
+++ b/test/gtest/test_nvmefs_proxy.cpp
@@ -638,6 +638,90 @@ TEST_F(DiskInteractionTest, WriteOutOfMetadataAssignedLBARangeForTmpFile) {
 	delete[] data_ptr;
 }
 
+TEST_F(DiskInteractionTest, TrimUnwrittenLocationInFile) {
+	int page_size = 4096 * 64; // One page
+
+	// Create a file
+	string file_path = "nvmefs://test.db";
+	unique_ptr<FileHandle> file =
+	    file_system->OpenFile(file_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_READ);
+
+	ASSERT_TRUE(file->GetFileSize() == 0);
+
+	// Attempt to write data out of range
+	file->Trim(0, page_size * 2);
+
+	EXPECT_EQ(file->GetFileSize(), page_size * 2);
+}
+
+TEST_F(DiskInteractionTest, TrimWrittenLocationInFileRemovesWrittenDataButKeepsSize) {
+	int page_size = 4096 * 64; // One page
+
+	// Create a file
+	string file_path = "nvmefs://test.db";
+	unique_ptr<FileHandle> file =
+	    file_system->OpenFile(file_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_READ);
+
+	ASSERT_TRUE(file != nullptr);
+
+	// Write some data to the file
+	string hello = "Hello, World!";
+	vector<char> data_ptr {hello.begin(), hello.end()};
+	int data_size = data_ptr.size();
+	file->Write(data_ptr.data(), data_size, page_size * 4); // Write data at the 16th byte of the device
+
+	// Read the data back
+	vector<char> buffer(data_size);
+	file->Read(buffer.data(), data_size, page_size * 4); // Read data from the 16th byte of the device
+
+	// Check that the data is correct
+	EXPECT_EQ(string(buffer.data(), data_size), hello);
+
+	file->Trim(page_size * 4, data_size);
+
+	memset(buffer.data(), 0, data_size);
+	file->Read(buffer.data(), data_size, page_size * 4); // Read data from the 16th byte of the device
+
+	// Check that the data is correct
+	EXPECT_NE(string(buffer.data(), data_size), hello);
+	EXPECT_EQ(file->GetFileSize(), page_size * 4 + 4096); // 4 pages + 1 lba
+}
+
+TEST_F(DiskInteractionTest, TrimWrittenLocationInFileFromSeekPositionRemovesWrittenDataButKeepsSize) {
+	int page_size = 4096 * 64; // One page
+
+	// Create a file
+	string file_path = "nvmefs://test.db";
+	unique_ptr<FileHandle> file =
+	    file_system->OpenFile(file_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_READ);
+
+	ASSERT_TRUE(file != nullptr);
+
+	// Write some data to the file
+	string hello = "Hello, World!";
+	vector<char> data_ptr {hello.begin(), hello.end()};
+	int data_size = data_ptr.size();
+	file->Write(data_ptr.data(), data_size, page_size * 4); // Write data at the 16th byte of the device
+
+	// Read the data back
+	vector<char> buffer(data_size);
+	file->Read(buffer.data(), data_size, page_size * 4); // Read data from the 16th byte of the device
+
+	// Check that the data is correct
+	EXPECT_EQ(string(buffer.data(), data_size), hello);
+
+	file->Seek(page_size * 3);
+
+	file->Trim(page_size, data_size);
+
+	memset(buffer.data(), 0, data_size);
+	file->Read(buffer.data(), data_size, page_size * 4); // Read data from the 16th byte of the device
+
+	// Check that the data is correct
+	EXPECT_NE(string(buffer.data(), data_size), hello);
+	EXPECT_EQ(file->GetFileSize(), page_size * 4 + 4096); // 4 pages + 1 lba
+}
+
 TEST_F(DiskInteractionTest, WriteAndReadInsideTmpFile) {
 	// Create a file
 	string file_path =

--- a/test/gtest/test_nvmefs_proxy.cpp
+++ b/test/gtest/test_nvmefs_proxy.cpp
@@ -732,8 +732,32 @@ TEST_F(BlockManagerTest, AllocateFreeAndAllocateAgainYieldsSameBlock) {
 	EXPECT_EQ(block2->IsFree(), is_free);
 }
 
-// TODO: Test that we can allocate three blocks deallocate the middle one and Allocate a larger object which is after
-// the third allocation
+TEST_F(BlockManagerTest,
+       AllocateSameSizeThreeTimesFreeTheMiddleAllocationAndAllocateALargerObjectYieldsBlockAfterBlock3) {
+
+	// Allocate a block of size 8
+	TemporaryBlock *block = block_manager->AllocateBlock(8);
+	TemporaryBlock *block2 = block_manager->AllocateBlock(8);
+	TemporaryBlock *block3 = block_manager->AllocateBlock(8);
+
+	ASSERT_TRUE(block->GetStartLBA() == 0);
+	ASSERT_TRUE(block2->GetStartLBA() == block->GetEndLBA() + 1);
+	ASSERT_TRUE(block3->GetStartLBA() == block2->GetEndLBA() + 1);
+	ASSERT_TRUE(block3->GetEndLBA() == block3->GetStartLBA() + 7);
+
+	// Check that the block is allocated correctly
+	idx_t start_lba = block2->GetStartLBA();
+	idx_t end_lba = block2->GetEndLBA();
+
+	block_manager->FreeBlock(block2);
+	TemporaryBlock *block4 = block_manager->AllocateBlock(16);
+
+	EXPECT_EQ(block4->GetStartLBA(), block3->GetEndLBA() + 1);
+	EXPECT_EQ(block4->GetEndLBA(), block4->GetStartLBA() + 15);
+	EXPECT_EQ(block4->GetSizeInBytes(), 16 * 4096);
+	EXPECT_EQ(block4->IsFree(), false);
+}
+
 // TODO: Create a test that allocates three blocks and deallocate them one by one. In the end allocate all of them again
 // in one block and see that it has been consolidated correctly
 

--- a/test/gtest/test_nvmefs_proxy.cpp
+++ b/test/gtest/test_nvmefs_proxy.cpp
@@ -684,52 +684,52 @@ protected:
 TEST_F(BlockManagerTest, FirstAllocateBlock) {
 
 	// Allocate a block of size 8
-	TemporaryBlock &block = block_manager->AllocateBlock(8);
+	TemporaryBlock *block = block_manager->AllocateBlock(8);
 
 	// Check that the block is allocated correctly
-	EXPECT_EQ(block.GetStartLBA(), 0);
-	EXPECT_EQ(block.GetEndLBA(), 7);
-	EXPECT_EQ(block.GetSizeInBytes(), 8 * 4096);
-	EXPECT_EQ(block.IsFree(), false);
+	EXPECT_EQ(block->GetStartLBA(), 0);
+	EXPECT_EQ(block->GetEndLBA(), 7);
+	EXPECT_EQ(block->GetSizeInBytes(), 8 * 4096);
+	EXPECT_EQ(block->IsFree(), false);
 }
 
 TEST_F(BlockManagerTest, AllocateTwiceInARow) {
 
 	// Allocate a block of size 8
-	TemporaryBlock &block = block_manager->AllocateBlock(8);
-	TemporaryBlock &block2 = block_manager->AllocateBlock(8);
+	TemporaryBlock *block = block_manager->AllocateBlock(8);
+	TemporaryBlock *block2 = block_manager->AllocateBlock(8);
 
 	// Check that the block is allocated correctly
-	EXPECT_EQ(block.GetStartLBA(), 0);
-	EXPECT_EQ(block.GetEndLBA(), 7);
-	EXPECT_EQ(block.GetSizeInBytes(), 8 * 4096);
-	EXPECT_EQ(block.IsFree(), false);
+	EXPECT_EQ(block->GetStartLBA(), 0);
+	EXPECT_EQ(block->GetEndLBA(), 7);
+	EXPECT_EQ(block->GetSizeInBytes(), 8 * 4096);
+	EXPECT_EQ(block->IsFree(), false);
 
-	EXPECT_EQ(block2.GetStartLBA(), 8);
-	EXPECT_EQ(block2.GetEndLBA(), 15);
-	EXPECT_EQ(block2.GetSizeInBytes(), 8 * 4096);
-	EXPECT_EQ(block2.IsFree(), false);
-	EXPECT_EQ(block.GetEndLBA() + 1, block2.GetStartLBA());
+	EXPECT_EQ(block2->GetStartLBA(), 8);
+	EXPECT_EQ(block2->GetEndLBA(), 15);
+	EXPECT_EQ(block2->GetSizeInBytes(), 8 * 4096);
+	EXPECT_EQ(block2->IsFree(), false);
+	EXPECT_EQ(block->GetEndLBA() + 1, block2->GetStartLBA());
 }
 
 TEST_F(BlockManagerTest, AllocateFreeAndAllocateAgainYieldsSameBlock) {
 
 	// Allocate a block of size 8
-	TemporaryBlock &block = block_manager->AllocateBlock(8);
+	TemporaryBlock *block = block_manager->AllocateBlock(8);
 
 	// Check that the block is allocated correctly
-	idx_t start_lba = block.GetStartLBA();
-	idx_t end_lba = block.GetEndLBA();
-	idx_t size = block.GetSizeInBytes();
-	bool is_free = block.IsFree();
+	idx_t start_lba = block->GetStartLBA();
+	idx_t end_lba = block->GetEndLBA();
+	idx_t size = block->GetSizeInBytes();
+	bool is_free = block->IsFree();
 
 	block_manager->FreeBlock(block);
-	TemporaryBlock &block2 = block_manager->AllocateBlock(8);
+	TemporaryBlock *block2 = block_manager->AllocateBlock(8);
 
-	EXPECT_EQ(block2.GetStartLBA(), start_lba);
-	EXPECT_EQ(block2.GetEndLBA(), end_lba);
-	EXPECT_EQ(block2.GetSizeInBytes(), size);
-	EXPECT_EQ(block2.IsFree(), is_free);
+	EXPECT_EQ(block2->GetStartLBA(), start_lba);
+	EXPECT_EQ(block2->GetEndLBA(), end_lba);
+	EXPECT_EQ(block2->GetSizeInBytes(), size);
+	EXPECT_EQ(block2->IsFree(), is_free);
 }
 
 // TODO: Test that we can allocate three blocks deallocate the middle one and Allocate a larger object which is after

--- a/test/gtest/test_nvmefs_proxy.cpp
+++ b/test/gtest/test_nvmefs_proxy.cpp
@@ -675,7 +675,7 @@ class BlockManagerTest : public testing::Test {
 protected:
 	BlockManagerTest() {
 		// Set up the test environment
-		block_manager = make_uniq<NvmeTemporaryBlockManager>(0, 1024);
+		block_manager = make_uniq<NvmeTemporaryBlockManager>(0, 1024 - 1); // 0 index...
 	}
 
 	unique_ptr<NvmeTemporaryBlockManager> block_manager;


### PR DESCRIPTION
# Why is this change necessary?

We observed that the read and write patterns of `DuckDBs` temporary files is happening in parallel. We thought that they only used one buffer size and wrote that particular file to the capacity before creating a new file. That "assumption" was wrong. 

## What is the solution?

The solution to the problem was to create an LBA "block" allocator, that we can reserve for each temporary file that is created. This obviously makes storing a file scattered on the range allocated for the temporary data, but it is necessary in order to keep track of the random behavior.

### Commits

- **feat: introduce locks for every method in public api**
- **feat: add debug prints to determine if deadlock**
- **fix: remove lock from seekposition**
- **fix: lock on read/write without location**
- **Add header file for temporary block allocator**
- **Implement initial block and block manager**
- **Change to use raw pointer such that we have a lower memory footprint**
- **Add linked list functions to easily handle push and pop**
- **Implement nvme block manager functions**
- **Register the temp block manager**
- **Add reasigning the header of the `blocks` list**
- **Create initial tests**
- **Remove destructor**
- **Init pointer in a temporary block**
- **Fix issues with not initialized block ptrs in PopFreeblock**
- **Fix lba start and end calculation(zero index)**
- **Adjust to use pointers instead**
- **Change lba start and end calculation to keep lba_amount to original value**
- **Add test to see that it frees correctly and allocate largers blocks after**
- **Add misc**
- **Fix split block pointer issue**
- **Remove debug print statements**
- **Fix coalesce to not call nullptr**
- **Add a last block so that it does not coalesce with the big original block**
- **Fix coalece to better clean up stuff**
- **Add temp block manager to nvmefs**
- **Change file exists to use the metadata directly**
- **Implement clean of temporary blocks in truncate**
- **Add seek**
- **Change temp_block_manager to be a pointer**
- **Refactor various methods to align with new way of handling temporary data (#50)**
- **Remove common lba functions**
- **Fix GetFileSize**
- **Remember to update tfmeta**
- **Update tfmeta in truncate**
- **Fix truncate loop**
- **Fix index**
- **Print block map size**
- **Print size after truncate**
- **Fix block index in loop**
- **Implement Trim in NvmeFileSystem**
- **Implement Reset, ListFiles, GetAvailableDiskSpace**
- **feat: remove debug cout prints**
- **feat: remove printf debug statements**