### PR TITLE
Add thread local `thread index`

### DIFF
--- a/src/include/nvme_device.hpp
+++ b/src/include/nvme_device.hpp
@@ -97,7 +97,7 @@ private:
 	bool fdp;
 	vector<xnvme_queue*> queues;
 	const idx_t max_threads;
-	static std::recursive_mutex init_lock;
+	vector<std::once_flag> init_queue_flags;
 };
 
 } // namespace duckdb

--- a/src/include/nvme_device.hpp
+++ b/src/include/nvme_device.hpp
@@ -22,7 +22,8 @@ struct NvmeCmdContext : public CmdContext {
 
 class NvmeDevice : public Device {
 public:
-	NvmeDevice(const string &device_path, const idx_t placement_handles, const string &backend, const bool async, const idx_t max_threads);
+	NvmeDevice(const string &device_path, const idx_t placement_handles, const string &backend, const bool async,
+	           const idx_t max_threads);
 	~NvmeDevice();
 
 	/// @brief Writes data from the input buffer to the device at the specified LBA position
@@ -84,7 +85,7 @@ private:
 	void PrepareIOCmdContext(xnvme_cmd_ctx *ctx, const CmdContext &cmd_ctx, idx_t plid_idx, idx_t dtype, bool write);
 	bool CheckFDP();
 	void InitializePlacementHandles();
-	void GetThreadIndex();
+	idx_t GetThreadIndex();
 
 private:
 	map<string, uint8_t> allocated_placement_identifiers;
@@ -96,10 +97,10 @@ private:
 	const string backend;
 	const bool async;
 	bool fdp;
-	vector<xnvme_queue*> queues;
+	vector<xnvme_queue *> queues;
 	const idx_t max_threads;
 	atomic<idx_t> thread_id_counter;
-	static thread_local idx_t index;
+	static thread_local optional_idx index;
 	vector<std::once_flag> init_queue_flags;
 };
 

--- a/src/include/nvme_device.hpp
+++ b/src/include/nvme_device.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb/common/map.hpp"
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "device.hpp"
 #include <libxnvme.h>

--- a/src/include/nvme_device.hpp
+++ b/src/include/nvme_device.hpp
@@ -102,7 +102,6 @@ private:
 	const idx_t max_threads;
 	atomic<idx_t> thread_id_counter;
 	static thread_local optional_idx index;
-	vector<std::once_flag> init_queue_flags;
 };
 
 } // namespace duckdb

--- a/src/include/nvme_device.hpp
+++ b/src/include/nvme_device.hpp
@@ -84,6 +84,7 @@ private:
 	void PrepareIOCmdContext(xnvme_cmd_ctx *ctx, const CmdContext &cmd_ctx, idx_t plid_idx, idx_t dtype, bool write);
 	bool CheckFDP();
 	void InitializePlacementHandles();
+	void GetThreadIndex();
 
 private:
 	map<string, uint8_t> allocated_placement_identifiers;
@@ -97,7 +98,8 @@ private:
 	bool fdp;
 	vector<xnvme_queue*> queues;
 	const idx_t max_threads;
-	atomic<idx_t> global_thread_id;
+	atomic<idx_t> thread_id_counter;
+	static thread_local idx_t index;
 	vector<std::once_flag> init_queue_flags;
 };
 

--- a/src/include/nvme_device.hpp
+++ b/src/include/nvme_device.hpp
@@ -97,6 +97,7 @@ private:
 	bool fdp;
 	vector<xnvme_queue*> queues;
 	const idx_t max_threads;
+	atomic<idx_t> global_thread_id;
 	vector<std::once_flag> init_queue_flags;
 };
 

--- a/src/nvme_device.cpp
+++ b/src/nvme_device.cpp
@@ -336,7 +336,6 @@ void NvmeDevice::InitializePlacementHandles() {
 idx_t NvmeDevice::GetThreadIndex() {
 	if (!index.IsValid()) {
 		index = thread_id_counter++ % max_threads;
-		printf("Creating Thread index: %d\n", index.GetIndex());
 	}
 
 	return index.GetIndex();

--- a/src/nvme_device.cpp
+++ b/src/nvme_device.cpp
@@ -333,6 +333,7 @@ void NvmeDevice::InitializePlacementHandles() {
 idx_t NvmeDevice::GetThreadIndex() {
 	if (!index.IsValid()) {
 		index = thread_id_counter++ % max_threads;
+		printf("Creating Thread index: %d\n", index.GetIndex());
 	}
 
 	return index.GetIndex();

--- a/src/nvme_device.cpp
+++ b/src/nvme_device.cpp
@@ -179,8 +179,8 @@ idx_t NvmeDevice::ReadAsync(void *buffer, const CmdContext &context) {
 	uint32_t nsid = xnvme_dev_get_nsid(device);
 	uint8_t plid_idx = GetPlacementIdentifierOrDefault(ctx.filepath);
 
-	idx_t thread_id = TaskScheduler::GetEstimatedCPUId();
-	idx_t index = thread_id % max_threads;
+
+	thread_local idx_t index = (global_thread_id++) % max_threads;
 
 	std::call_once(init_queue_flags[index], [&](){
 		int err = xnvme_queue_init(device, XNVME_QUEUE_DEPTH, 0, &queues[index]);

--- a/src/nvme_device.cpp
+++ b/src/nvme_device.cpp
@@ -1,6 +1,7 @@
 #include "nvme_device.hpp"
 
 namespace duckdb {
+thread_local optional_idx NvmeDevice::index = optional_idx();
 NvmeDevice::NvmeDevice(const string &device_path, const idx_t placement_handles, const string &backend,
                        const bool async, const idx_t max_threads)
     : dev_path(device_path), plhdls(placement_handles), backend(backend), async(async), max_threads(max_threads) {

--- a/src/nvme_device.cpp
+++ b/src/nvme_device.cpp
@@ -1,7 +1,6 @@
 #include "nvme_device.hpp"
 
 namespace duckdb {
-thread_local idx_t NvmeDevice::index = -1;
 NvmeDevice::NvmeDevice(const string &device_path, const idx_t placement_handles, const string &backend,
                        const bool async, const idx_t max_threads)
     : dev_path(device_path), plhdls(placement_handles), backend(backend), async(async), max_threads(max_threads) {
@@ -15,7 +14,7 @@ NvmeDevice::NvmeDevice(const string &device_path, const idx_t placement_handles,
 
 	// Initialize the xnvme queue for asynchronous IO
 	if (async) {
-		queues = vector<xnvme_queue*>(max_threads, nullptr);
+		queues = vector<xnvme_queue *>(max_threads, nullptr);
 		init_queue_flags = vector<std::once_flag>(max_threads);
 		// Set the callback function for completed commands. No callback arguments, hence last argument equal to NULL
 	}
@@ -33,7 +32,7 @@ NvmeDevice::NvmeDevice(const string &device_path, const idx_t placement_handles,
 
 NvmeDevice::~NvmeDevice() {
 	if (async) {
-		for(const auto &queue : queues){
+		for (const auto &queue : queues) {
 			xnvme_queue_term(queue);
 		}
 	}
@@ -155,7 +154,7 @@ void NvmeDevice::PrepareOpts(xnvme_opts &opts) {
 
 void NvmeDevice::CommandCallback(struct xnvme_cmd_ctx *ctx, void *cb_args) {
 	// Cast callback args into defined callback struct
-	std::promise<void> *notifier = (std::promise<void> *) cb_args;
+	std::promise<void> *notifier = (std::promise<void> *)cb_args;
 
 	// Check status
 	if (xnvme_cmd_ctx_cpl_status(ctx)) {
@@ -180,14 +179,16 @@ idx_t NvmeDevice::ReadAsync(void *buffer, const CmdContext &context) {
 	uint32_t nsid = xnvme_dev_get_nsid(device);
 	uint8_t plid_idx = GetPlacementIdentifierOrDefault(ctx.filepath);
 
-	std::call_once(init_queue_flags[index], [&](){
-		int err = xnvme_queue_init(device, XNVME_QUEUE_DEPTH, 0, &queues[index]);
+	idx_t thread_index = GetThreadIndex();
+
+	std::call_once(init_queue_flags[thread_index], [&]() {
+		int err = xnvme_queue_init(device, XNVME_QUEUE_DEPTH, 0, &queues[thread_index]);
 		if (err) {
 			xnvme_cli_perr("Unable to create an queue for asynchronous IO", err);
 		}
 	});
 
-	xnvme_queue *queue = queues[index];
+	xnvme_queue *queue = queues[thread_index];
 
 	xnvme_cmd_ctx *xnvme_ctx = xnvme_queue_get_cmd_ctx(queue);
 	PrepareIOCmdContext(xnvme_ctx, context, plid_idx, 0, false);
@@ -231,14 +232,16 @@ idx_t NvmeDevice::WriteAsync(void *buffer, const CmdContext &context) {
 	uint32_t nsid = xnvme_dev_get_nsid(device);
 	uint8_t plid_idx = GetPlacementIdentifierOrDefault(ctx.filepath);
 
-	std::call_once(init_queue_flags[index], [&](){
-		int err = xnvme_queue_init(device, XNVME_QUEUE_DEPTH, 0, &queues[index]);
+	idx_t thread_index = GetThreadIndex();
+
+	std::call_once(init_queue_flags[thread_index], [&]() {
+		int err = xnvme_queue_init(device, XNVME_QUEUE_DEPTH, 0, &queues[thread_index]);
 		if (err) {
 			xnvme_cli_perr("Unable to create an queue for asynchronous IO", err);
 		}
 	});
 
-	xnvme_queue *queue = queues[index];
+	xnvme_queue *queue = queues[thread_index];
 
 	xnvme_cmd_ctx *xnvme_ctx = xnvme_queue_get_cmd_ctx(queue);
 	PrepareIOCmdContext(xnvme_ctx, context, plid_idx, DATA_PLACEMENT_MODE, true);
@@ -267,7 +270,8 @@ idx_t NvmeDevice::WriteAsync(void *buffer, const CmdContext &context) {
 	return ctx.nr_lbas;
 }
 
-void NvmeDevice::PrepareIOCmdContext(xnvme_cmd_ctx *ctx, const CmdContext &cmd_ctx, idx_t plid_idx, idx_t dtype, bool write) {
+void NvmeDevice::PrepareIOCmdContext(xnvme_cmd_ctx *ctx, const CmdContext &cmd_ctx, idx_t plid_idx, idx_t dtype,
+                                     bool write) {
 	const NvmeCmdContext &nvme_cmd_ctx = static_cast<const NvmeCmdContext &>(cmd_ctx);
 
 	// Specified by the command set specification:
@@ -290,10 +294,10 @@ bool NvmeDevice::CheckFDP() {
 	xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(device);
 	uint32_t nsid = xnvme_dev_get_nsid(device);
 	uint8_t feat_id = 0x1D; // identifier of fdp
-	uint8_t sel = 0x0; // look up current value
+	uint8_t sel = 0x0;      // look up current value
 
 	xnvme_prep_adm_gfeat(&ctx, nsid, feat_id, sel);
-	//ctx.cmd.gfeat.cdw11 = 0x1;
+	// ctx.cmd.gfeat.cdw11 = 0x1;
 
 	int err = xnvme_cmd_pass_admin(&ctx, NULL, 0x0, NULL, 0x0);
 	if (err) {
@@ -311,8 +315,8 @@ void NvmeDevice::InitializePlacementHandles() {
 	// Retrieve number of RUHs on the device
 	struct xnvme_spec_ruhs header;
 	uint32_t header_bytes = sizeof(header);
-	xnvme_nvm_mgmt_recv(&xnvme_ctx, nsid, XNVME_SPEC_IO_MGMT_RECV_RUHS,0, &header, header_bytes);
-	uint16_t max_placement_handles = header.nruhsd-1;
+	xnvme_nvm_mgmt_recv(&xnvme_ctx, nsid, XNVME_SPEC_IO_MGMT_RECV_RUHS, 0, &header, header_bytes);
+	uint16_t max_placement_handles = header.nruhsd - 1;
 
 	// Retrieve information about recliam unit handles
 	struct xnvme_spec_ruhs *ruhs = nullptr;
@@ -321,14 +325,16 @@ void NvmeDevice::InitializePlacementHandles() {
 	memset(ruhs, 0, ruhs_nbytes);
 	xnvme_nvm_mgmt_recv(&xnvme_ctx, nsid, XNVME_SPEC_IO_MGMT_RECV_RUHS, 0, ruhs, ruhs_nbytes);
 
-	for(int i = 0; i < max_placement_handles; ++i) {
+	for (int i = 0; i < max_placement_handles; ++i) {
 		placement_handlers.emplace_back(ruhs->desc[i].pi);
 	}
 }
 
-void NvmeDevice::GetThreadIndex() {
-	if(index == -1) {
+idx_t NvmeDevice::GetThreadIndex() {
+	if (!index.IsValid()) {
 		index = thread_id_counter++ % max_threads;
 	}
+
+	return index.GetIndex();
 }
 } // namespace duckdb


### PR DESCRIPTION

- **feat: change init of queue to call once**
- **fix: try with thread_local index**
- **fix: global thread local index**
- **fix: move getThreadIndex to constructor**
- **Use duckdb::optional_idx to provide a default value for thread local**
- **Add print**
- **Add init and import of optional index**
- **Remove call once**
- **Remove print**
