### PR TITLE
Remove old references to `plhdls`

### DIFF
--- a/test/e2e/basic/test_open_and_close_database.py
+++ b/test/e2e/basic/test_open_and_close_database.py
@@ -12,7 +12,6 @@ def test_create_database_close_and_open(device):
     con.execute(f"""CREATE OR REPLACE PERSISTENT SECRET nvmefs (
                         TYPE NVMEFS,
                         nvme_device_path '{device.device_path}',
-                        fdp_plhdls       '{7}',
                         backend         'io_uring_cmd'
                     );""")
 

--- a/test/e2e/basic/test_temporary.py
+++ b/test/e2e/basic/test_temporary.py
@@ -15,7 +15,6 @@ def tpch_database_connection(device):
     con.execute(f"""CREATE OR REPLACE PERSISTENT SECRET nvmefs (
                         TYPE NVMEFS,
                         nvme_device_path '{device.device_path}',
-                        fdp_plhdls       '{7}',
                         backend          'io_uring_cmd'
                     );""")
 

--- a/test/gtest/utils/gtest_utils.hpp
+++ b/test/gtest/utils/gtest_utils.hpp
@@ -8,7 +8,6 @@ static bool DeallocDevice();
 
 static const struct NvmeConfig TEST_CONFIG {
     .device_path = "/dev/ng1n1",
-    .plhdls = 8,
     .max_temp_size = 1 << 30, // 1 GiB in bytes
     .max_wal_size = 1 << 25   // 32 MiB
 };


### PR DESCRIPTION
# What was the issue?

After defending the master thesis, we cleaned up the project. However, we have missed some old references in the test suites to the field `plhdls` that was used to specify the amount of placement handles that is configured. This is no longer needed, since the information can be extracted from the device itself. 

This PR removes those references
