### PR TITLE
Add VCPKG and boost install to dev container

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -5,7 +5,9 @@ sudo bash -i ./scripts/xnvme/install.sh
 
 # Install dev dependencies
 sudo apt update
-sudo apt install -y ccache vim curl zip
+
+# TODO: Remove libboost-all-dev and use the libraries installed via vcpkg
+sudo apt install -y ccache vim curl zip libboost-all-dev
 
 # Setup tools directory
 mkdir -p ~/.tools/bin
@@ -17,6 +19,7 @@ cd vcpkg && ./bootstrap-vcpkg.sh
 VCPKG_ROOT=~/.tools/vcpkg
 
 echo "export VCPKG_ROOT='$VCPKG_ROOT'" >> ~/.bashrc
+echo "export VCPKG_TOOLCHAIN_PATH='$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake'" >> ~/.bashrc
 echo "export PATH='$PATH:$VCPKG_ROOT'" >> ~/.bashrc 
 
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash


### PR DESCRIPTION

Since our CMAKE file cannot include the boost library correctly at the moment, the boot library needs to be installed globally on the system... for now.
