### PR TITLE
Refactor mutex declarations to inline static

### DIFF
--- a/src/include/nvmefs.hpp
+++ b/src/include/nvmefs.hpp
@@ -130,6 +130,6 @@ private:
 	atomic<idx_t> wal_location;
 	idx_t max_temp_size;
 	idx_t max_wal_size;
-	static std::recursive_mutex temp_lock;
+	inline static std::recursive_mutex temp_lock;
 };
 } // namespace duckdb

--- a/src/include/temporary_file_metadata_manager.hpp
+++ b/src/include/temporary_file_metadata_manager.hpp
@@ -59,6 +59,6 @@ private:
 	idx_t lba_amount;
 	unique_ptr<NvmeTemporaryBlockManager> block_manager;
 	map<string, unique_ptr<TempFileMetadata>> file_to_temp_meta;
-	static boost::shared_mutex temp_mutex;
+	inline static boost::shared_mutex temp_mutex;
 };
 } // namespace duckdb

--- a/src/nvmefs.cpp
+++ b/src/nvmefs.cpp
@@ -63,7 +63,7 @@ idx_t NvmeFileHandle::GetFilePointer() {
 
 ////////////////////////////////////////
 
-std::recursive_mutex NvmeFileSystem::temp_lock;
+//std::recursive_mutex NvmeFileSystem::temp_lock;
 
 NvmeFileSystem::NvmeFileSystem(NvmeConfig config)
     : allocator(Allocator::DefaultAllocator()),

--- a/src/temporary_file_metadata_manager.cpp
+++ b/src/temporary_file_metadata_manager.cpp
@@ -55,7 +55,7 @@ inline unique_ptr<TempFileMetadata> CreateTempFileMetadata(const string &filenam
 	return std::move(tfmeta);
 }
 
-boost::shared_mutex TemporaryFileMetadataManager::temp_mutex;
+//boost::shared_mutex TemporaryFileMetadataManager::temp_mutex;
 
 const TempFileMetadata *TemporaryFileMetadataManager::GetOrCreateFile(const string &filename) {
 


### PR DESCRIPTION
Change mutex declarations to inline static to be able to build the debug build